### PR TITLE
AMQP subscription

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,9 @@ subscription = Twingly::AMQP::Subscription.new(
   connection:       amqp_connection, # Optional, creates new AMQP::Connection if not set
 )
 
+subscription.on_exception { |exception| puts "Oh noes! #{exception.message}" }
+subscription.before_handle_message { |raw_message| puts raw_message }
+
 subscription.subscribe do |payload|
   # The payload is parsed JSON
   puts payload[:some_key]

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![Build Status](https://travis-ci.org/twingly/twingly-amqp.svg?branch=master)](https://travis-ci.org/twingly/twingly-amqp)
 
 
-A gem for sending pings via RabbitMQ.
+A gem for subscribing and publishing messages via RabbitMQ.
 
 ## Installation
 
@@ -19,13 +19,30 @@ gem "twingly-amqp", :git => "git@github.com:twingly/twingly-amqp.git"
 amqp_connection = Twingly::AMQP::Connection(
   hosts: # Optional, uses ENV[/RABBITMQ_\d+_HOST/] by default
 )
+```
 
+### Subscribe to a queue
+
+```ruby
+subscription = Twingly::AMQP::Subscription.new(
+  queue_name:       "queue-to-subscribe-to",
+  exchange_topic:   "exchange-name-to-connect-queue-to",
+  routing_key:      "blog.url.#",
+  consumer_threads: 4, # Optional
+  prefetch:         20, # Optional
+  connection:       amqp_connection, # Optional, creates new AMQP::Connection if not set
+)
+```
+
+### Ping urls
+
+```ruby
 pinger = Twingly::AMQP::Ping.new(
   provider_name: "a-provider-name",
   queue_name:    "provider-ping",
   source_ip:     "?.?.?.?",
   priority:      1,
-  connection:    amqp_connection, # Optional, creates new AMQP::Connection otherwise
+  connection:    amqp_connection, # Optional, creates new AMQP::Connection if not set
   url_cache:     url_cache, # Optional, see below
 )
 
@@ -38,7 +55,7 @@ pinger.ping(urls) do |pinged_url|
 end
 ```
 
-### Url cache
+#### Url cache
 
 `Twingly::AMQP::Ping.new` can optionally take an url cache which caches the urls and only pings in the urls that isn't already cached. The cache needs to respond to the two following methods:
 

--- a/README.md
+++ b/README.md
@@ -25,9 +25,9 @@ amqp_connection = Twingly::AMQP::Connection(
 
 ```ruby
 subscription = Twingly::AMQP::Subscription.new(
-  queue_name:       "queue-to-subscribe-to",
-  exchange_topic:   "exchange-name-to-connect-queue-to",
-  routing_key:      "blog.url.#",
+  queue_name:       "crawler-urls",
+  exchange_topic:   "url-exchange",
+  routing_key:      "url.blog",
   consumer_threads: 4, # Optional
   prefetch:         20, # Optional
   connection:       amqp_connection, # Optional, creates new AMQP::Connection if not set

--- a/README.md
+++ b/README.md
@@ -32,6 +32,11 @@ subscription = Twingly::AMQP::Subscription.new(
   prefetch:         20, # Optional
   connection:       amqp_connection, # Optional, creates new AMQP::Connection if not set
 )
+
+subscription.subscribe do |payload|
+  # The payload is parsed JSON
+  puts payload[:some_key]
+end
 ```
 
 ### Ping urls

--- a/lib/twingly/amqp.rb
+++ b/lib/twingly/amqp.rb
@@ -1,4 +1,5 @@
 require "twingly/amqp/version"
 
 require "twingly/amqp/connection"
+require "twingly/amqp/subscription"
 require "twingly/amqp/ping"

--- a/lib/twingly/amqp.rb
+++ b/lib/twingly/amqp.rb
@@ -1,5 +1,7 @@
 require "twingly/amqp/version"
 
+ENV["RUBY_ENV"] ||= "development"
+
 require "twingly/amqp/connection"
 require "twingly/amqp/subscription"
 require "twingly/amqp/ping"

--- a/lib/twingly/amqp/subscription.rb
+++ b/lib/twingly/amqp/subscription.rb
@@ -1,0 +1,124 @@
+require "raven"
+
+module Twingly
+  module AMQP
+    class Subscription
+      def initialize(queue_name:, exchange_topic:, routing_key:, consumer_threads: 4, prefetch: 20, connection: nil)
+        @queue_name       = queue_name
+        @exchange_topic   = exchange_topic
+        @routing_key      = routing_key
+        @consumer_threads = consumer_threads
+        @prefetch         = prefetch
+
+        connection ||= Connection.new.connection
+        @channel = create_channel(connection)
+      end
+
+      def subscribe(&block)
+        queue    = @channel.queue(@queue_name, queue_options)
+        exchange = @channel.topic(@exchange_topic, durable: true)
+        queue.bind(exchange, routing_key: @routing_key)
+
+        setup_traps
+
+        consumer = queue.subscribe(subscribe_options) do |delivery_info, metadata, payload|
+          begin
+            Raven::Context.clear!
+            Raven.extra_context(payload: payload)
+
+            handle_message_payload(payload, &block)
+
+            @channel.ack(delivery_info.delivery_tag)
+          rescue
+            @channel.reject(delivery_info.delivery_tag)
+            raise
+          end
+        end
+
+        # The consumer isn't blocking, so we wait here
+        until cancel? do
+          sleep 0.5
+        end
+
+        puts "Shutting down" if development?
+        consumer.cancel
+      end
+
+      private
+
+      def create_channel(connection)
+        channel = connection.create_channel(nil, @consumer_threads)
+        channel.prefetch(@prefetch)
+        channel.on_uncaught_exception do |exception, _|
+          puts exception.message, exception.backtrace if development?
+          Raven.capture_exception(exception)
+        end
+        channel
+      end
+
+      def development?
+        ruby_env == "development"
+      end
+
+      def ruby_env
+        ENV.fetch("RUBY_ENV")
+      end
+
+      def queue_options
+        {
+          durable: true,
+        }
+      end
+
+      def subscribe_options
+        {
+          manual_ack:   true,
+          consumer_tag: consumer_tag,
+        }
+      end
+
+      def consumer_tag
+        tag_name = [Socket.gethostname, ruby_env].join('-')
+        @channel.generate_consumer_tag(tag_name)
+      end
+
+      def cancel?
+        @cancel
+      end
+
+      def cancel!
+        @cancel = true
+      end
+
+      def setup_traps
+        [:INT, :TERM].each do |signal|
+          Signal.trap(signal) do
+            # Exit fast if we've already got a signal since before
+            exit!(true) if cancel?
+
+            # Set cancel flag, cancels consumers
+            cancel!
+          end
+        end
+      end
+
+      def handle_message_payload(payload, &block)
+        messages = parse_message_payload(payload)
+
+        messages.each do |message|
+          block.call(message)
+        end
+      end
+
+      def parse_message_payload(payload)
+        result = JSON.parse(payload, symbolize_names: true)
+
+        if result.is_a?(Array)
+          result
+        else
+          [result]
+        end
+      end
+    end
+  end
+end

--- a/twingly-amqp.gemspec
+++ b/twingly-amqp.gemspec
@@ -18,6 +18,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency "bunny", "~> 2"
+  spec.add_dependency "sentry-raven"
 
   spec.add_development_dependency "rspec", "~> 3"
   spec.add_development_dependency "rake", "~> 10.0"

--- a/twingly-amqp.gemspec
+++ b/twingly-amqp.gemspec
@@ -18,7 +18,6 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency "bunny", "~> 2"
-  spec.add_dependency "sentry-raven"
 
   spec.add_development_dependency "rspec", "~> 3"
   spec.add_development_dependency "rake", "~> 10.0"


### PR DESCRIPTION
close #4

Added a class for subscribing to queues. The code is roughly the same as in chapman and zambezi.

Tested it by using `rabbitmqadmin`:

```shell
$ rabbitmqadmin declare exchange name=binlog-test type=topic

$ bundle console
> s = Twingly::AMQP::Subscription.new(queue_name: "testing-twingly-amqp", routing_key: "testing.#", exchange_topic: "binlog-test")
> s.subscribe do |message|
>   puts message
> end
```

```shell
$ rabbitmqadmin publish exchange=binlog-test routing_key="testing.test" payload='{"message": "hello!"}'
```

Tests for this would be nice, but I don't know how to do. I don't know how you should test `Subscription#subscribe` since it blocks the starting thread.