### PR TITLE
Make connection class a singleton

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,10 +22,14 @@ Environment variables:
 * `AMQP_PASSWORD`
 * `AMQP_TLS` # Use TLS connection if set
 
+### Customize options
+
+If you don't have the RabbitMQ hosts in your ENV you can set them with `Twingly::AMQP::Connection.connection` before you create an instance of `Subscription` or `Ping`.
+
 ```ruby
-amqp_connection = Twingly::AMQP::Connection(
-  hosts: # Optional, uses ENV[/RABBITMQ_\d+_HOST/] by default
-)
+Twingly::AMQP::Connection.options = {
+  hosts: "localhost",
+}
 ```
 
 ### Subscribe to a queue
@@ -37,7 +41,6 @@ subscription = Twingly::AMQP::Subscription.new(
   routing_key:      "url.blog",
   consumer_threads: 4, # Optional
   prefetch:         20, # Optional
-  connection:       amqp_connection, # Optional, creates new AMQP::Connection if not set
 )
 
 subscription.on_exception { |exception| puts "Oh noes! #{exception.message}" }
@@ -57,7 +60,6 @@ pinger = Twingly::AMQP::Ping.new(
   queue_name:    "provider-ping",
   source_ip:     "?.?.?.?",
   priority:      1,
-  connection:    amqp_connection, # Optional, creates new AMQP::Connection if not set
   url_cache:     url_cache, # Optional, see below
 )
 

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Environment variables:
 
 ### Customize options
 
-If you don't have the RabbitMQ hosts in your ENV you can set them with `Twingly::AMQP::Connection.connection` before you create an instance of `Subscription` or `Ping`.
+If you don't have the RabbitMQ hosts in your ENV you can set them with `Twingly::AMQP::Connection.options=` before you create an instance of `Subscription` or `Ping`.
 
 ```ruby
 Twingly::AMQP::Connection.options = {

--- a/lib/twingly/amqp.rb
+++ b/lib/twingly/amqp.rb
@@ -2,6 +2,7 @@ require "twingly/amqp/version"
 
 ENV["RUBY_ENV"] ||= "development"
 
+require "twingly/amqp/session"
 require "twingly/amqp/connection"
 require "twingly/amqp/subscription"
 require "twingly/amqp/ping"

--- a/lib/twingly/amqp/connection.rb
+++ b/lib/twingly/amqp/connection.rb
@@ -3,45 +3,22 @@ require "bunny"
 module Twingly
   module AMQP
     class Connection
-      attr_reader :connection
+      private_class_method :new
 
-      def initialize(hosts: nil)
-        @optional_hosts = hosts
-        @connection     = create_connection
+      @@lock     = Mutex.new
+      @@instance = nil
+      @@options  = {}
+
+      def self.options=(options)
+        @@options = options
       end
 
-      private
-
-      def create_connection
-        if ruby_env == "development"
-          connection = Bunny.new
-        else
-          connection_options = {
-            hosts: amqp_hosts,
-            user: ENV.fetch("AMQP_USERNAME"),
-            pass: ENV.fetch("AMQP_PASSWORD"),
-            recover_from_connection_close: true,
-            tls: tls?,
-          }
-          connection = Bunny.new(connection_options)
+      def self.instance
+        return @@instance if @@instance
+        @@lock.synchronize do
+          return @@instance if @@instance
+          @@instance = Session.new(@@options).connection
         end
-        connection.start
-        connection
-      end
-
-      def ruby_env
-        ENV.fetch("RUBY_ENV")
-      end
-
-      def tls?
-        ENV.has_key?("AMQP_TLS")
-      end
-
-      def amqp_hosts
-        return @optional_hosts if @optional_hosts
-        # Matches env keys like `RABBITMQ_01_HOST`
-        environment_keys_with_host = ENV.keys.select { |key| key =~ /^rabbitmq_\d+_host$/i }
-        environment_keys_with_host.map { |key| ENV[key] }
       end
     end
   end

--- a/lib/twingly/amqp/connection.rb
+++ b/lib/twingly/amqp/connection.rb
@@ -1,3 +1,4 @@
+require "twingly/amqp/session"
 require "bunny"
 
 module Twingly

--- a/lib/twingly/amqp/ping.rb
+++ b/lib/twingly/amqp/ping.rb
@@ -12,7 +12,7 @@ module Twingly
         @source_ip     = source_ip
         @priority      = priority
 
-        connection ||= Connection.new.connection
+        connection ||= Connection.instance
         @channel = connection.create_channel
       end
 

--- a/lib/twingly/amqp/session.rb
+++ b/lib/twingly/amqp/session.rb
@@ -1,0 +1,45 @@
+module Twingly
+  module AMQP
+    class Session
+      attr_reader :connection, :hosts
+
+      def initialize(hosts: nil)
+        @hosts      = hosts || hosts_from_env
+        @connection = create_connection
+      end
+
+      private
+
+      def create_connection
+        if ruby_env == "development"
+          connection = Bunny.new
+        else
+          connection_options = {
+            hosts: hosts,
+            user: ENV.fetch("AMQP_USERNAME"),
+            pass: ENV.fetch("AMQP_PASSWORD"),
+            recover_from_connection_close: true,
+            tls: tls?,
+          }
+          connection = Bunny.new(connection_options)
+        end
+        connection.start
+        connection
+      end
+
+      def ruby_env
+        ENV.fetch("RUBY_ENV")
+      end
+
+      def tls?
+        ENV.has_key?("AMQP_TLS")
+      end
+
+      def hosts_from_env
+        # Matches env keys like `RABBITMQ_01_HOST`
+        environment_keys_with_host = ENV.keys.select { |key| key =~ /^rabbitmq_\d+_host$/i }
+        environment_keys_with_host.map { |key| ENV[key] }
+      end
+    end
+  end
+end

--- a/lib/twingly/amqp/subscription.rb
+++ b/lib/twingly/amqp/subscription.rb
@@ -1,3 +1,6 @@
+require "twingly/amqp/connection"
+require "json"
+
 module Twingly
   module AMQP
     class Subscription

--- a/lib/twingly/amqp/subscription.rb
+++ b/lib/twingly/amqp/subscription.rb
@@ -8,7 +8,7 @@ module Twingly
         @consumer_threads = consumer_threads
         @prefetch         = prefetch
 
-        connection ||= Connection.new.connection
+        connection ||= Connection.instance
         @channel = create_channel(connection)
 
         @queue   = @channel.queue(@queue_name, queue_options)

--- a/spec/amqp_queue_context.rb
+++ b/spec/amqp_queue_context.rb
@@ -2,7 +2,7 @@ shared_context "amqp queue" do
   let(:queue_name)    { "twingly-amqp.test" }
 
   let(:amqp_connection) do
-    Twingly::AMQP::Connection.new.connection
+    Twingly::AMQP::Connection.instance
   end
 
   let(:amqp_queue) do

--- a/spec/twingly/connection_spec.rb
+++ b/spec/twingly/connection_spec.rb
@@ -1,28 +1,16 @@
 describe Twingly::AMQP::Connection do
-  describe ".new" do
-    let(:host) { "localhost" }
-    let(:rabbitmq_host_env_name) { "RABBITMQ_01_HOST" }
+  subject { described_class }
+  it { is_expected.to     respond_to(:options=) }
+  it { is_expected.to     respond_to(:instance) }
+  it { is_expected.not_to respond_to(:new) }
 
-    context "without arguments" do
-      it "should read them from ENV" do
-        expect { described_class.new }.to_not raise_exception
-      end
-    end
+  describe ".instance" do
+    context "when called multiple times" do
+      it "should return the same instance each time" do
+        first_connection  = described_class.instance
+        second_connection = described_class.instance
 
-    context "when given hosts array as argument" do
-      it "should not read them from ENV" do
-        expect(ENV).not_to receive(:[]).with(rabbitmq_host_env_name)
-
-        described_class.new(hosts: [ host ])
-      end
-    end
-
-    context "when AMQP_TLS is set" do
-      before { ENV["AMQP_TLS"] = "oh yeah" }
-      after  { ENV.delete("AMQP_TLS") }
-
-      it "should enable tls for bunny" do
-        expect { described_class.new }.to raise_error(Bunny::TCPConnectionFailedForAllHosts)
+        expect(first_connection).to equal(second_connection)
       end
     end
   end

--- a/spec/twingly/session_spec.rb
+++ b/spec/twingly/session_spec.rb
@@ -1,0 +1,29 @@
+describe Twingly::AMQP::Session do
+  describe ".new" do
+    let(:hosts) { [ "localhost" ] }
+    let(:rabbitmq_host_env_name) { "RABBITMQ_01_HOST" }
+
+    context "without arguments" do
+      it "should read them from ENV" do
+        expect { described_class.new }.to_not raise_exception
+      end
+    end
+
+    context "when given hosts array as argument" do
+      it "should not read them from ENV" do
+        expect(ENV).not_to receive(:[]).with(rabbitmq_host_env_name)
+
+        described_class.new(hosts: hosts)
+      end
+    end
+
+    context "when AMQP_TLS is set" do
+      before { ENV["AMQP_TLS"] = "oh yeah" }
+      after  { ENV.delete("AMQP_TLS") }
+
+      it "should enable tls for bunny" do
+        expect { described_class.new }.to raise_error(Bunny::TCPConnectionFailedForAllHosts)
+      end
+    end
+  end
+end


### PR DESCRIPTION
close #10

* `Session` - The class which sets up the amqp connection (is used by `Connection.instance`) 
* `Connection.options=` - can be used to set amqp hosts if they are not stored in ENV.
* `Connection.instance` 
  * Creates a `Session` object the first time its called 
  * Returns the same amqp connection (`session.connection`) each time its called

Took inspiration for the singleton pattern from http://stackoverflow.com/a/5259578

### Todo

- [x] Make it possible to just require one of the classes (such as `require "twingly/amqp/subscription"`) (9a3d4c3ee6ecb1d35736b989523ce5cb8191d2b9)