### PR TITLE
Create class for handling messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,9 +47,13 @@ subscription.on_exception { |exception| puts "Oh noes! #{exception.message}" }
 subscription.before_handle_message { |raw_message_payload| puts raw_message }
 
 subscription.subscribe do |message| # An instance of Twingly::AMQP::Message
-  puts message.payload[:some_key]
+  response = client.post(payload.fetch(:url))
 
-  message.requeue! # Requeues the message, see Twingly::AMQP::Message
+  case response.code
+  when 200 then message.ack     # No error
+  when 404 then message.reject  # Permanent error, discard
+  when 500 then message.requeue # Transient error, retry
+  end
 end
 ```
 

--- a/README.md
+++ b/README.md
@@ -44,11 +44,12 @@ subscription = Twingly::AMQP::Subscription.new(
 )
 
 subscription.on_exception { |exception| puts "Oh noes! #{exception.message}" }
-subscription.before_handle_message { |raw_message| puts raw_message }
+subscription.before_handle_message { |raw_message_payload| puts raw_message }
 
-subscription.subscribe do |payload|
-  # The payload is parsed JSON
-  puts payload[:some_key]
+subscription.subscribe do |message| # An instance of Twingly::AMQP::Message
+  puts message.payload[:some_key]
+
+  message.requeue! # Requeues the message, see Twingly::AMQP::Message
 end
 ```
 

--- a/lib/twingly/amqp/message.rb
+++ b/lib/twingly/amqp/message.rb
@@ -14,8 +14,6 @@ module Twingly
         @metadata      = metadata
         @payload       = parse_payload(payload)
         @status        = ACK
-
-        yield self if block_given?
       end
 
       def ack!

--- a/lib/twingly/amqp/message.rb
+++ b/lib/twingly/amqp/message.rb
@@ -3,41 +3,25 @@ require "json"
 module Twingly
   module AMQP
     class Message
-      ACK     = :ack
-      REQUEUE = :requeue
-      DISCARD = :discard
-
       attr_reader :delivery_info, :metadata, :payload
 
-      def initialize(delivery_info:, metadata:, payload:)
+      def initialize(delivery_info:, metadata:, payload:, channel:)
         @delivery_info = delivery_info
         @metadata      = metadata
         @payload       = parse_payload(payload)
-        @status        = ACK
+        @channel       = channel
       end
 
-      def ack!
-        @status = ACK
+      def ack
+        @channel.ack(@delivery_info.delivery_tag)
       end
 
-      def requeue!
-        @status = REQUEUE
+      def requeue
+        @channel.reject(@delivery_info.delivery_tag, true)
       end
 
-      def discard!
-        @status = DISCARD
-      end
-
-      def ack?
-        @status == ACK
-      end
-
-      def requeue?
-        @status == REQUEUE
-      end
-
-      def discard?
-        @status == DISCARD
+      def reject
+        @channel.reject(@delivery_info.delivery_tag, false)
       end
 
       private

--- a/lib/twingly/amqp/message.rb
+++ b/lib/twingly/amqp/message.rb
@@ -7,7 +7,7 @@ module Twingly
       REQUEUE = :requeue
       DISCARD = :discard
 
-      attr_accessor :status, :delivery_info, :metadata, :payload
+      attr_reader :delivery_info, :metadata, :payload
 
       def initialize(delivery_info:, metadata:, payload:)
         @delivery_info = delivery_info
@@ -18,28 +18,28 @@ module Twingly
         yield self if block_given?
       end
 
-      def ack
-        status = ACK
+      def ack!
+        @status = ACK
       end
 
-      def requeue
-        status = REQUEUE
+      def requeue!
+        @status = REQUEUE
       end
 
-      def discard
-        status = DISCARD
+      def discard!
+        @status = DISCARD
       end
 
       def ack?
-        status == ACK
+        @status == ACK
       end
 
       def requeue?
-        status == REQUEUE
+        @status == REQUEUE
       end
 
       def discard?
-        status == DISCARD
+        @status == DISCARD
       end
 
       private

--- a/lib/twingly/amqp/message.rb
+++ b/lib/twingly/amqp/message.rb
@@ -1,0 +1,47 @@
+require "json"
+
+module Twingly
+  module AMQP
+    class Message
+      ACK     = :ack
+      REQUEUE = :requeue
+      DISCARD = :discard
+
+      attr_accessor :status, :delivery_info, :metadata, :payload
+
+      def initialize(delivery_info:, metadata:, payload:)
+        @delivery_info = delivery_info
+        @metadata      = metadata
+        @payload       = payload
+
+        @status = :ack
+
+        yield self if block_given?
+      end
+
+      def ack
+        status = ACK
+      end
+
+      def requeue
+        status = REQUEUE
+      end
+
+      def discard
+        status = DISCARD
+      end
+
+      def ack?
+        status == ACK
+      end
+
+      def requeue?
+        status == REQUEUE
+      end
+
+      def discard?
+        status == DISCARD
+      end
+    end
+  end
+end

--- a/lib/twingly/amqp/message.rb
+++ b/lib/twingly/amqp/message.rb
@@ -12,9 +12,8 @@ module Twingly
       def initialize(delivery_info:, metadata:, payload:)
         @delivery_info = delivery_info
         @metadata      = metadata
-        @payload       = payload
-
-        @status = :ack
+        @payload       = parse_payload(payload)
+        @status        = ACK
 
         yield self if block_given?
       end
@@ -41,6 +40,12 @@ module Twingly
 
       def discard?
         status == DISCARD
+      end
+
+      private
+
+      def parse_payload(payload)
+        JSON.parse(payload, symbolize_names: true)
       end
     end
   end

--- a/lib/twingly/amqp/subscription.rb
+++ b/lib/twingly/amqp/subscription.rb
@@ -32,18 +32,13 @@ module Twingly
             message = Message.new(
               delivery_info: delivery_info,
               metadata:      metadata,
-              payload:       payload
+              payload:       payload,
+              channel:       @channel,
             )
 
             block.call(message)
-
-            if message.ack?
-              @channel.ack(delivery_info.delivery_tag)
-            else
-              @channel.reject(delivery_info.delivery_tag, message.requeue?)
-            end
           rescue
-            @channel.reject(delivery_info.delivery_tag)
+            @channel.reject(delivery_info.delivery_tag, false)
             raise
           end
         end

--- a/lib/twingly/amqp/subscription.rb
+++ b/lib/twingly/amqp/subscription.rb
@@ -26,21 +26,16 @@ module Twingly
         setup_traps
 
         consumer = @queue.subscribe(subscribe_options) do |delivery_info, metadata, payload|
-          begin
-            @before_handle_message_callback.call(payload)
+          @before_handle_message_callback.call(payload)
 
-            message = Message.new(
-              delivery_info: delivery_info,
-              metadata:      metadata,
-              payload:       payload,
-              channel:       @channel,
-            )
+          message = Message.new(
+            delivery_info: delivery_info,
+            metadata:      metadata,
+            payload:       payload,
+            channel:       @channel,
+          )
 
-            block.call(message)
-          rescue
-            @channel.reject(delivery_info.delivery_tag, false)
-            raise
-          end
+          block.call(message)
         end
 
         # The consumer isn't blocking, so we wait here

--- a/spec/twingly/message_spec.rb
+++ b/spec/twingly/message_spec.rb
@@ -1,0 +1,83 @@
+describe Twingly::AMQP::Message do
+  let(:delivery_info) { "delivery_info" }
+  let(:metadata)      { "metadata" }
+  let(:payload)       { { url: "test.se" } }
+  let(:message_data) do
+    {
+      delivery_info: delivery_info,
+      metadata:      metadata,
+      payload:       payload.to_json,
+    }
+  end
+
+  subject { described_class.new(message_data) }
+  it { is_expected.to respond_to(:delivery_info) }
+  it { is_expected.to respond_to(:metadata) }
+  it { is_expected.to respond_to(:payload) }
+
+  describe "#delivery_info" do
+    it "should return the delivery info" do
+      expect(subject.delivery_info).to eq(delivery_info)
+    end
+  end
+
+  describe "#metadata" do
+    it "should return metadata" do
+      expect(subject.metadata).to eq(metadata)
+    end
+  end
+
+  describe "#payload" do
+    it "should return payload as parsed json" do
+      expect(subject.payload).to eq(payload)
+    end
+  end
+
+  describe "#ack?" do
+    context "by default" do
+      it "should be true" do
+        expect(subject.ack?).to eq(true)
+      end
+    end
+
+    context "when another status is set" do
+      before { subject.requeue! }
+
+      it "should be false" do
+        expect(subject.ack?).to eq(false)
+      end
+    end
+  end
+
+  describe "#requeue?" do
+    context "by default" do
+      it "should be false" do
+        expect(subject.requeue?).to eq(false)
+      end
+    end
+
+    context "when it is set" do
+      before { subject.requeue! }
+
+      it "should be true" do
+        expect(subject.requeue?).to eq(true)
+      end
+    end
+  end
+
+  describe "#discard?" do
+    context "by default" do
+      it "should be false" do
+        expect(subject.discard?).to eq(false)
+      end
+    end
+
+    context "when it is set" do
+      before { subject.discard! }
+
+      it "should be true" do
+        expect(subject.discard?).to eq(true)
+      end
+    end
+  end
+end

--- a/spec/twingly/subscription_spec.rb
+++ b/spec/twingly/subscription_spec.rb
@@ -27,8 +27,8 @@ describe Twingly::AMQP::Subscription do
         sleep 1
 
         received_url = nil
-        subject.subscribe do |payload|
-          received_url = payload[:url]
+        subject.subscribe do |message|
+          received_url = message.payload[:url]
           subject.cancel!
         end
 
@@ -48,8 +48,8 @@ describe Twingly::AMQP::Subscription do
         sleep 1
 
         received_url = nil
-        subject.subscribe do |payload|
-          received_url = payload[:url]
+        subject.subscribe do |message|
+          received_url = message.payload[:url]
           subject.cancel!
         end
 


### PR DESCRIPTION
close #13

`subscriber.subscribe` gives an instance of the message class to the block instead of just the payload.

Makes it possible for the client to requeue and discard messages, and read the messages metadata etc.

### Todo

- [x] Create tests for message
- [x] Update subscriber tests