### PR TITLE
Allow more options

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,8 @@ Environment variables:
 
 If you don't have the RabbitMQ hosts, user or password in your ENV you can set them with `Twingly::AMQP::Connection.options=` before you create an instance of `Subscription` or `Ping`.
 
+*Options set in `Connection.options=` take precedence over the options defined in `ENV`.*
+
 All options are sent to `Bunny.new`, see the [documentation][ruby-bunny] for all available options.
 
 ```ruby

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Environment variables:
 
 If you don't have the RabbitMQ hosts, user or password in your ENV you can set them with `Twingly::AMQP::Connection.options=` before you create an instance of `Subscription` or `Ping`.
 
-All options are sent to `Bunny.new`, see the documentation at [ruby-bunny][] for all available options.
+All options are sent to `Bunny.new`, see the [documentation][ruby-bunny] for all available options.
 
 ```ruby
 Twingly::AMQP::Connection.options = {

--- a/README.md
+++ b/README.md
@@ -28,13 +28,20 @@ Environment variables:
 
 ### Customize options
 
-If you don't have the RabbitMQ hosts in your ENV you can set them with `Twingly::AMQP::Connection.options=` before you create an instance of `Subscription` or `Ping`.
+If you don't have the RabbitMQ hosts, user or password in your ENV you can set them with `Twingly::AMQP::Connection.options=` before you create an instance of `Subscription` or `Ping`.
+
+All options are sent to `Bunny.new`, see the documentation at [ruby-bunny][] for all available options.
 
 ```ruby
 Twingly::AMQP::Connection.options = {
-  hosts: "localhost",
+  hosts: %w(localhost),
+  user: "a-user",
+  pass: "1234",
+  # ...
 }
 ```
+
+[ruby-bunny]: http://rubybunny.info/articles/connecting.html
 
 ### Subscribe to a queue
 

--- a/lib/twingly/amqp/session.rb
+++ b/lib/twingly/amqp/session.rb
@@ -30,7 +30,6 @@ module Twingly
 
       def default_connection_options
         {
-          recover_from_connection_close: true,
           tls: tls?,
         }
       end

--- a/twingly-amqp.gemspec
+++ b/twingly-amqp.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |spec|
   spec.files        = Dir.glob("{lib}/**/*") + %w(README.md)
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "bunny", "~> 2"
+  spec.add_dependency "bunny", "~> 2.2"
 
   spec.add_development_dependency "rspec", "~> 3"
   spec.add_development_dependency "rake", "~> 10.0"


### PR DESCRIPTION
Sends all options set in `Twingly::AMQP::Connection.options=` directly to Bunny. Needed for https://github.com/twingly/ganges/pull/44

close #25