### PR TITLE
Set expiration per ping

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,8 +79,10 @@ end
 
 ```ruby
 pinger = Twingly::AMQP::Pinger.new(
-  queue_name:    "provider-ping",
-  url_cache:     url_cache, # Optional, see below
+  queue_name:      "provider-ping",
+  ping_expiration: 2_000,     # Optional, ms, discard the ping if it's still on
+                              #   the queue after this amount of milliseconds
+  url_cache:       url_cache, # Optional, see below
 )
 
 # Optional, options can also be given to #ping

--- a/lib/twingly/amqp/pinger.rb
+++ b/lib/twingly/amqp/pinger.rb
@@ -5,13 +5,14 @@ require "json"
 module Twingly
   module AMQP
     class Pinger
-      def initialize(queue_name:, url_cache: NullCache, connection: nil)
+      def initialize(queue_name:, ping_expiration: nil, url_cache: NullCache, connection: nil)
         @queue_name = queue_name
         @url_cache  = url_cache
 
         connection ||= Connection.instance
         @channel = connection.create_channel
 
+        @ping_expiration      = ping_expiration
         @default_ping_options = PingOptions.new
       end
 
@@ -47,6 +48,7 @@ module Twingly
           key: @queue_name,
           persistent: true,
           content_type: "application/json",
+          expiration: @ping_expiration,
         }
       end
 

--- a/spec/twingly/pinger_spec.rb
+++ b/spec/twingly/pinger_spec.rb
@@ -24,6 +24,29 @@ describe Twingly::AMQP::Pinger do
       }
     end
 
+    context "when expiration has been set" do
+      let(:ping_expiration) { 2_000 } # ms
+      subject do
+        described_class.new(
+          queue_name:      queue_name,
+          connection:      amqp_connection,
+          ping_expiration: ping_expiration,
+        )
+      end
+
+      before do
+        subject.ping(urls, ping_options)
+      end
+
+      it "the ping should be discarded after it expires" do
+        expect(amqp_queue.message_count).to eq(1)
+
+        sleep ping_expiration / 1000
+
+        expect(amqp_queue.message_count).to eq(0)
+      end
+    end
+
     context "with all required options set" do
       before do
         subject.ping(urls, ping_options)


### PR DESCRIPTION
RabbitMQ cannot change queue-length and queue-message-ttl, the queue has to be deleted and then redeclared.
We wanted to be able to change this value easily, so we had to use per-message-ttl instead.

This is needed for the queue between norrstrom and klondike.

see https://trello.com/c/Setqn4Fd