### PR TITLE
Minor improvements and fix unreliable test case

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,12 @@ Run tests with
 bundle exec rake
 ```
 
+Run just the unit tests with
+
+```shell
+bundle exec rake spec:unit
+```
+
 ## Release workflow
 
 **Note**: Make sure you are logged in as [twingly][twingly-rubygems] at RubyGems.org.

--- a/lib/twingly/amqp/pinger.rb
+++ b/lib/twingly/amqp/pinger.rb
@@ -45,7 +45,7 @@ module Twingly
 
       def amqp_publish_options
         {
-          key: @queue_name,
+          routing_key: @queue_name,
           persistent: true,
           content_type: "application/json",
           expiration: @ping_expiration,

--- a/spec/integration/twingly/amqp/pinger_spec.rb
+++ b/spec/integration/twingly/amqp/pinger_spec.rb
@@ -36,6 +36,7 @@ describe Twingly::AMQP::Pinger do
 
       before do
         subject.ping(urls, ping_options)
+        sleep 1
       end
 
       it "the ping should be discarded after it expires" do

--- a/spec/integration/twingly/amqp/pinger_spec.rb
+++ b/spec/integration/twingly/amqp/pinger_spec.rb
@@ -36,6 +36,8 @@ describe Twingly::AMQP::Pinger do
 
       before do
         subject.ping(urls, ping_options)
+
+        # wait until the ping has been published to target queue
         sleep 1
       end
 

--- a/spec/integration/twingly/amqp/session_spec.rb
+++ b/spec/integration/twingly/amqp/session_spec.rb
@@ -57,6 +57,8 @@ describe Twingly::AMQP::Session do
         after  { ENV.delete("AMQP_TLS") }
 
         it "should enable tls for bunny" do
+          # since we do not have tls setup when running the tests
+          # this will fail with the specified error
           expect { described_class.new }.to raise_error(Bunny::TCPConnectionFailedForAllHosts)
         end
       end


### PR DESCRIPTION
Fix #42.

I took the easy sleeping route here as that's what we did
in all other tests.

I think it could be better to check the queue length
something like "wait until we can see message on queue" but I couldn't find
a, simple, reliable solution, during my tests I would, sometimes, end up with for-ever sleeping threads.
I believe there are timing issues at hand that are hard to "quick fix".