### PR TITLE
Remove sleeping in specs

### DIFF
--- a/lib/twingly/amqp/pinger.rb
+++ b/lib/twingly/amqp/pinger.rb
@@ -18,7 +18,7 @@ module Twingly
         @default_ping_options = PingOptions.new
       end
 
-      def ping(urls, options_hash = {})
+      def ping(urls, options_hash = {}, confirm_publish: false)
         options = PingOptions.new(options_hash)
         options = @default_ping_options.merge(options)
 
@@ -26,7 +26,7 @@ module Twingly
 
         Array(urls).each do |url|
           unless cached?(url)
-            publish(url, options)
+            publish(url, options, confirm_publish)
             cache!(url)
 
             yield url if block_given?
@@ -40,10 +40,14 @@ module Twingly
 
       private
 
-      def publish(url, options)
+      def publish(url, options, confirm_publish)
         payload = message(url, options)
 
-        @publisher.publish(payload)
+        if confirm_publish
+          @publisher.publish_with_confirm(payload)
+        else
+          @publisher.publish(payload)
+        end
       end
 
       def message(url, options)

--- a/spec/integration/twingly/amqp/pinger_spec.rb
+++ b/spec/integration/twingly/amqp/pinger_spec.rb
@@ -7,6 +7,7 @@ describe Twingly::AMQP::Pinger do
     described_class.new(
       queue_name: queue_name,
       connection: amqp_connection,
+      confirm_publish: true,
     )
   end
 
@@ -31,11 +32,12 @@ describe Twingly::AMQP::Pinger do
           queue_name:      queue_name,
           connection:      amqp_connection,
           ping_expiration: ping_expiration,
+          confirm_publish: true,
         )
       end
 
       before do
-        subject.ping(urls, ping_options, confirm_publish: true)
+        subject.ping(urls, ping_options)
       end
 
       it "the ping should be discarded after it expires" do
@@ -49,7 +51,7 @@ describe Twingly::AMQP::Pinger do
 
     context "with all required options set" do
       before do
-        subject.ping(urls, ping_options, confirm_publish: true)
+        subject.ping(urls, ping_options)
       end
 
       context "with one URL" do

--- a/spec/integration/twingly/amqp/pinger_spec.rb
+++ b/spec/integration/twingly/amqp/pinger_spec.rb
@@ -35,10 +35,7 @@ describe Twingly::AMQP::Pinger do
       end
 
       before do
-        subject.ping(urls, ping_options)
-
-        # wait until the ping has been published to target queue
-        sleep 1
+        subject.ping(urls, ping_options, confirm_publish: true)
       end
 
       it "the ping should be discarded after it expires" do
@@ -52,8 +49,7 @@ describe Twingly::AMQP::Pinger do
 
     context "with all required options set" do
       before do
-        subject.ping(urls, ping_options)
-        sleep 1
+        subject.ping(urls, ping_options, confirm_publish: true)
       end
 
       context "with one URL" do

--- a/spec/integration/twingly/amqp/subscription_spec.rb
+++ b/spec/integration/twingly/amqp/subscription_spec.rb
@@ -18,6 +18,7 @@ describe Twingly::AMQP::Subscription do
   let(:routing_key)    { "url.blog" }
   let(:exchange) do
     channel = amqp_connection.create_channel
+    channel.confirm_select
     channel.topic(exchange_topic, durable: true)
   end
 
@@ -33,7 +34,7 @@ describe Twingly::AMQP::Subscription do
     context "when message has same routing key" do
       it "should receive the message published on the exchange" do
         exchange.publish(payload_json, routing_key: routing_key)
-        sleep 1
+        exchange.wait_for_confirms
 
         received_url = nil
         subject.each_message do |message|
@@ -54,7 +55,7 @@ describe Twingly::AMQP::Subscription do
         end
 
         exchange.publish(payload_json, routing_key: routing_key)
-        sleep 1
+        exchange.wait_for_confirms
 
         received_url = nil
         subject.each_message do |message|
@@ -69,7 +70,7 @@ describe Twingly::AMQP::Subscription do
     context "when a before_handle_message callback has been set" do
       it "should call the callback" do
         exchange.publish(payload_json, routing_key: routing_key)
-        sleep 1
+        exchange.wait_for_confirms
 
         unparsed_payload = nil
         subject.before_handle_message do |raw_payload|
@@ -84,7 +85,7 @@ describe Twingly::AMQP::Subscription do
     context "when an error is raised" do
       it "should call error callback" do
         exchange.publish("this is not json", routing_key: routing_key)
-        sleep 1
+        exchange.wait_for_confirms
 
         on_exception_called = false
         subject.on_exception do |_|
@@ -99,7 +100,9 @@ describe Twingly::AMQP::Subscription do
 
     context "without exchange_topic and routing_key" do
       let(:default_exchange) do
-        amqp_connection.create_channel.default_exchange
+        channel = amqp_connection.create_channel
+        channel.confirm_select
+        channel.default_exchange
       end
 
       subject! do
@@ -110,7 +113,7 @@ describe Twingly::AMQP::Subscription do
 
       it "should subscribe to default exchange" do
         default_exchange.publish(payload_json, routing_key: queue_name)
-        sleep 1
+        exchange.wait_for_confirms
 
         received_url = nil
         subject.each_message do |message|


### PR DESCRIPTION
Close #44. Makes spec run on about 20% of the time of before :-).

Can be tidied up when we can publish to exchanges (#12).