### PR TITLE
Improve release instructions and update change log

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,100 @@
-# Changelog
+# Change Log
 
-## `v4.1.0`
+## [Unreleased](https://github.com/twingly/twingly-amqp/tree/HEAD)
 
-* Set expiration per ping [#37](https://github.com/twingly/twingly-amqp/pull/37)
+[Full Changelog](https://github.com/twingly/twingly-amqp/compare/v4.1.0...HEAD)
 
-## `v4.0.0`
+**Implemented enhancements:**
 
-* Optionally set provider and priority per ping [#31](https://github.com/twingly/twingly-amqp/pull/31)
-* Rename `Subscription#subscribe` to `#each_message` [#35](https://github.com/twingly/twingly-amqp/pull/35)
-* Rename `Twingly::AMQP::Ping` to `Pinger` [#34](https://github.com/twingly/twingly-amqp/pull/34)
-* Remove `RUBY_ENV` usage [#36](https://github.com/twingly/twingly-amqp/pull/36)
+- Guidelines how to test applications that use this library [\#11](https://github.com/twingly/twingly-amqp/issues/11)
+
+**Fixed bugs:**
+
+- Timeout threshold too low, increase or refactor? [\#44](https://github.com/twingly/twingly-amqp/issues/44)
+- Test suite not reliable? [\#42](https://github.com/twingly/twingly-amqp/issues/42)
+
+**Merged pull requests:**
+
+- Remove sleeping in specs [\#50](https://github.com/twingly/twingly-amqp/pull/50) ([walro](https://github.com/walro))
+- Add RuboCop [\#48](https://github.com/twingly/twingly-amqp/pull/48) ([walro](https://github.com/walro))
+- Introduce class for publishing to queues [\#47](https://github.com/twingly/twingly-amqp/pull/47) ([walro](https://github.com/walro))
+- Minor improvements and fix unreliable test case [\#43](https://github.com/twingly/twingly-amqp/pull/43) ([walro](https://github.com/walro))
+- Add instance documentation to README [\#41](https://github.com/twingly/twingly-amqp/pull/41) ([walro](https://github.com/walro))
+- Split specs into integration and unit directories [\#38](https://github.com/twingly/twingly-amqp/pull/38) ([dentarg](https://github.com/dentarg))
+
+## [v4.1.0](https://github.com/twingly/twingly-amqp/tree/v4.1.0) (2015-12-09)
+[Full Changelog](https://github.com/twingly/twingly-amqp/compare/v4.0.0...v4.1.0)
+
+**Merged pull requests:**
+
+- Set expiration per ping [\#37](https://github.com/twingly/twingly-amqp/pull/37) ([roback](https://github.com/roback))
+
+## [v4.0.0](https://github.com/twingly/twingly-amqp/tree/v4.0.0) (2015-12-08)
+[Full Changelog](https://github.com/twingly/twingly-amqp/compare/v3.3.0...v4.0.0)
+
+**Implemented enhancements:**
+
+- Rename Twingly::AMQP::Ping to Pinger [\#33](https://github.com/twingly/twingly-amqp/issues/33)
+- Add changelog [\#32](https://github.com/twingly/twingly-amqp/issues/32)
+- Rename Twingly::AMQP::Subscription\#subscribe [\#28](https://github.com/twingly/twingly-amqp/issues/28)
+- Improve test for Session.new without arguments [\#16](https://github.com/twingly/twingly-amqp/issues/16)
+
+**Fixed bugs:**
+
+- RUBY\_ENV should not matter [\#30](https://github.com/twingly/twingly-amqp/issues/30)
+
+**Merged pull requests:**
+
+- Remove RUBY\_ENV usage [\#36](https://github.com/twingly/twingly-amqp/pull/36) ([roback](https://github.com/roback))
+- Rename Subscription\#subscribe to \#each\_message [\#35](https://github.com/twingly/twingly-amqp/pull/35) ([roback](https://github.com/roback))
+- Rename Twingly::AMQP::Ping to Pinger [\#34](https://github.com/twingly/twingly-amqp/pull/34) ([roback](https://github.com/roback))
+- Optionally set provider and priority per ping [\#31](https://github.com/twingly/twingly-amqp/pull/31) ([roback](https://github.com/roback))
+- Improve tests for Session.new without arguments [\#27](https://github.com/twingly/twingly-amqp/pull/27) ([roback](https://github.com/roback))
+
+## [v3.3.0](https://github.com/twingly/twingly-amqp/tree/v3.3.0) (2015-11-02)
+[Full Changelog](https://github.com/twingly/twingly-amqp/compare/v3.2.1...v3.3.0)
+
+**Implemented enhancements:**
+
+- Allow more connection options [\#25](https://github.com/twingly/twingly-amqp/issues/25)
+- Release to RubyGems [\#24](https://github.com/twingly/twingly-amqp/issues/24)
+
+**Merged pull requests:**
+
+- Allow more options [\#26](https://github.com/twingly/twingly-amqp/pull/26) ([roback](https://github.com/roback))
+
+## [v3.2.1](https://github.com/twingly/twingly-amqp/tree/v3.2.1) (2015-10-30)
+[Full Changelog](https://github.com/twingly/twingly-amqp/compare/v3.2.0...v3.2.1)
+
+## [v3.2.0](https://github.com/twingly/twingly-amqp/tree/v3.2.0) (2015-10-30)
+**Implemented enhancements:**
+
+- Add timeout for subscription tests [\#21](https://github.com/twingly/twingly-amqp/issues/21)
+- Make Connection class singleton [\#10](https://github.com/twingly/twingly-amqp/issues/10)
+- Add class for subscribing to a queue [\#4](https://github.com/twingly/twingly-amqp/issues/4)
+- Tests! [\#1](https://github.com/twingly/twingly-amqp/issues/1)
+
+**Fixed bugs:**
+
+- All messages are acked in Subscription\#subscribe [\#13](https://github.com/twingly/twingly-amqp/issues/13)
+
+**Closed issues:**
+
+- Option to enable AMQPS \(TLS\) [\#14](https://github.com/twingly/twingly-amqp/issues/14)
+- Set source ip per ping [\#6](https://github.com/twingly/twingly-amqp/issues/6)
+
+**Merged pull requests:**
+
+- Optionally set source ip per ping [\#23](https://github.com/twingly/twingly-amqp/pull/23) ([roback](https://github.com/roback))
+- Timeout for subscription tests [\#22](https://github.com/twingly/twingly-amqp/pull/22) ([roback](https://github.com/roback))
+- Subscribe to default exchange [\#20](https://github.com/twingly/twingly-amqp/pull/20) ([roback](https://github.com/roback))
+- Create class for handling messages [\#18](https://github.com/twingly/twingly-amqp/pull/18) ([roback](https://github.com/roback))
+- Make connection class a singleton [\#17](https://github.com/twingly/twingly-amqp/pull/17) ([roback](https://github.com/roback))
+- Allow TLS connections [\#15](https://github.com/twingly/twingly-amqp/pull/15) ([jage](https://github.com/jage))
+- Tests [\#9](https://github.com/twingly/twingly-amqp/pull/9) ([roback](https://github.com/roback))
+- AMQP subscription [\#8](https://github.com/twingly/twingly-amqp/pull/8) ([roback](https://github.com/roback))
+- Adapt gem for remora [\#5](https://github.com/twingly/twingly-amqp/pull/5) ([roback](https://github.com/roback))
+
+
+
+\* *This Change Log was automatically generated by [github_changelog_generator](https://github.com/skywinder/Github-Changelog-Generator)*

--- a/README.md
+++ b/README.md
@@ -173,10 +173,16 @@ To run static code analysis:
 
 ## Release workflow
 
-**Note**: Make sure you are logged in as [twingly][twingly-rubygems] at RubyGems.org.
+* Bump the version in `lib/twingly/amqp/version.rb` in a commit, no need to push (the release task does that).
 
-Build and [publish](http://guides.rubygems.org/publishing/) the gem.
+* Build and [publish](http://guides.rubygems.org/publishing/) the gem. This will create the proper tag in git, push the commit and tag and upload to RubyGems.
 
-    bundle exec rake release
+        bundle exec rake release
+
+    * If you are not logged in as [twingly][twingly-rubygems] with ruby gems, the rake task will fail and tell you to set credentials via `gem push`, do that and run the `release` task again. It will be okay.
+
+* Update the changelog with [GitHub Changelog Generator](https://github.com/skywinder/github-changelog-generator/) (`gem install github_changelog_generator` if you don't have it, set `CHANGELOG_GITHUB_TOKEN` to a personal access token to avoid rate limiting by GitHub). This command will update `CHANGELOG.md`, commit and push manually.
+
+        github_changelog_generator -u twingly -p twingly-amqp
 
 [twingly-rubygems]: https://rubygems.org/profiles/twingly


### PR DESCRIPTION
Instructions taken from https://github.com/twingly/twingly-url#release-workflow.

Close #52.