### PR TITLE
Non-blocking subscribe (#on_each_message)

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,19 @@ subscription.each_message do |message| # An instance of Twingly::AMQP::Message
 end
 ```
 
+#### Non-blocking subscription
+
+```ruby
+subscription.on_each_message do |message|
+  puts "Received #{message.payload.inspect}"
+  message.ack
+end
+
+# Do something
+
+subscription.cancel! # Stops the subscriber
+```
+
 ### Publish to a queue on the default exchange
 
 ```ruby

--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ end
 #### Non-blocking subscription
 
 ```ruby
-subscription.on_each_message do |message|
+subscription.each_message(blocking: false) do |message|
   puts "Received #{message.payload.inspect}"
   message.ack
 end

--- a/lib/twingly/amqp/subscription.rb
+++ b/lib/twingly/amqp/subscription.rb
@@ -28,7 +28,7 @@ module Twingly
         consumer = create_consumer(&block)
 
         # The consumer isn't blocking, so we wait here
-        sleep 0.5 until cancel?
+        sleep 0.01 until cancel?
 
         consumer.cancel
       end

--- a/lib/twingly/amqp/subscription.rb
+++ b/lib/twingly/amqp/subscription.rb
@@ -27,12 +27,11 @@ module Twingly
       def each_message(blocking: true, &block)
         consumer = create_consumer(&block)
 
-        return unless blocking
+        if blocking
+          sleep 0.01 until cancel?
 
-        # The consumer isn't blocking, so we wait here
-        sleep 0.01 until cancel?
-
-        consumer.cancel
+          consumer.cancel
+        end
       end
 
       def before_handle_message(&block)

--- a/lib/twingly/amqp/subscription.rb
+++ b/lib/twingly/amqp/subscription.rb
@@ -24,19 +24,15 @@ module Twingly
         @on_exception_callback          = proc {}
       end
 
-      def each_message(&block)
+      def each_message(blocking: true, &block)
         consumer = create_consumer(&block)
+
+        return unless blocking
 
         # The consumer isn't blocking, so we wait here
         sleep 0.01 until cancel?
 
         consumer.cancel
-      end
-
-      def on_each_message(&block)
-        setup_traps
-
-        create_consumer(&block)
       end
 
       def before_handle_message(&block)

--- a/spec/integration/twingly/amqp/subscription_spec.rb
+++ b/spec/integration/twingly/amqp/subscription_spec.rb
@@ -148,6 +148,8 @@ describe Twingly::AMQP::Subscription do
     end
 
     context "when blocking is false" do
+      let(:message_count) { 2 }
+
       after { subject.cancel! }
 
       it "should be non-blocking" do
@@ -161,16 +163,19 @@ describe Twingly::AMQP::Subscription do
         expect(is_non_blocking).to eq(true)
       end
 
-      it "should receive the message published on the exchange" do
-        received_url = nil
+      it "should receive the messages published on the exchange" do
+        received_urls = []
         subject.each_message(blocking: false) do |message|
-          received_url = message.payload[:url]
+          received_urls << message.payload[:url]
         end
 
-        exchange.publish(payload_json, routing_key: routing_key)
+        message_count.times do
+          exchange.publish(payload_json, routing_key: routing_key)
+        end
+
         exchange.wait_for_confirms
 
-        expect(received_url).to eq(payload_url)
+        expect(received_urls.count).to eq(message_count)
       end
     end
   end


### PR DESCRIPTION
I didn't want to duplicate all tests from `#each_message`, so I just copied the one I felt was most important (the one that makes sure it can receive a message from rabbitmq).

close #29