### PR TITLE
Require RuboCop >= 0.49

### DIFF
--- a/examples/default_exchange_publisher.rb
+++ b/examples/default_exchange_publisher.rb
@@ -7,4 +7,4 @@ publisher.configure_publish_options do |options|
   options.expiration = 5000
 end
 
-publisher.publish({ my: "data" })
+publisher.publish(my: "data")

--- a/examples/topic_exchange_publisher.rb
+++ b/examples/topic_exchange_publisher.rb
@@ -7,4 +7,4 @@ publisher.configure_publish_options do |options|
   options.expiration = 5000
 end
 
-publisher.publish({ my: "data" })
+publisher.publish(my: "data")

--- a/lib/twingly/amqp/pinger.rb
+++ b/lib/twingly/amqp/pinger.rb
@@ -26,12 +26,11 @@ module Twingly
         options.validate
 
         Array(urls).each do |url|
-          unless cached?(url)
-            publish(url, options)
-            cache!(url)
+          next if cached?(url)
+          publish(url, options)
+          cache!(url)
 
-            yield url if block_given?
-          end
+          yield url if block_given?
         end
       end
 
@@ -67,7 +66,7 @@ module Twingly
       end
 
       class NullCache
-        def self.cached?(url)
+        def self.cached?(_url)
           false
         end
 

--- a/lib/twingly/amqp/subscription.rb
+++ b/lib/twingly/amqp/subscription.rb
@@ -63,7 +63,7 @@ module Twingly
 
       private
 
-      def create_consumer(&block)
+      def create_consumer
         @queue.subscribe(subscribe_options) do |delivery_info, metadata, payload|
           @before_handle_message_callback.call(payload)
 
@@ -74,7 +74,7 @@ module Twingly
             channel:       @channel,
           )
 
-          block.call(message)
+          yield(message)
         end
       end
 
@@ -114,7 +114,7 @@ module Twingly
       end
 
       def setup_traps
-        [:INT, :TERM].each do |signal|
+        %i[INT TERM].each do |signal|
           Signal.trap(signal) do
             # Exit fast if we've already got a signal since before
             exit!(true) if cancel?

--- a/lib/twingly/amqp/subscription.rb
+++ b/lib/twingly/amqp/subscription.rb
@@ -74,7 +74,7 @@ module Twingly
             channel:       @channel,
           )
 
-          yield(message)
+          yield message
         end
       end
 

--- a/spec/integration/twingly/amqp/connection_spec.rb
+++ b/spec/integration/twingly/amqp/connection_spec.rb
@@ -13,7 +13,7 @@ describe Twingly::AMQP::Connection do
   end
 
   describe ".options=" do
-    let(:options) { { hosts: %w(host1 host2) } }
+    let(:options) { { hosts: %w[host1 host2] } }
 
     it "updates the configuration" do
       described_class.options = options

--- a/spec/integration/twingly/amqp/pinger_spec.rb
+++ b/spec/integration/twingly/amqp/pinger_spec.rb
@@ -79,7 +79,7 @@ describe Twingly::AMQP::Pinger do
 
       context "with an array of URLs" do
         let(:urls) do
-          %w(http://example.com http://test.se https://another-one.com)
+          %w[http://example.com http://test.se https://another-one.com]
         end
 
         it "should send multiple messages" do

--- a/twingly-amqp.gemspec
+++ b/twingly-amqp.gemspec
@@ -20,5 +20,5 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency "rspec", "~> 3"
   spec.add_development_dependency "rake", "~> 10.0"
-  spec.add_development_dependency "rubocop", "~> 0"
+  spec.add_development_dependency "rubocop", "~> 0.49"
 end

--- a/twingly-amqp.gemspec
+++ b/twingly-amqp.gemspec
@@ -1,4 +1,4 @@
-# coding: utf-8
+
 lib = File.expand_path("../lib", __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require "twingly/amqp/version"
@@ -13,12 +13,12 @@ Gem::Specification.new do |spec|
   spec.description   = "Publish and subscribe to messages via RabbitMQ"
   spec.homepage      = "https://github.com/twingly/twingly-amqp"
 
-  spec.files         = Dir.glob("{lib}/**/*") + %w(README.md)
+  spec.files         = Dir.glob("{lib}/**/*") + %w[README.md]
   spec.require_paths = ["lib"]
 
   spec.add_dependency "bunny", "~> 2.2"
 
-  spec.add_development_dependency "rspec", "~> 3"
   spec.add_development_dependency "rake", "~> 10.0"
+  spec.add_development_dependency "rspec", "~> 3"
   spec.add_development_dependency "rubocop", "~> 0.49"
 end


### PR DESCRIPTION
Takes care of CVE-2017-8418: https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2017-8418

Also let RuboCop autocorrect everything it finds.