### PR TITLE
Remove unused signal trap code

### DIFF
--- a/lib/twingly/amqp/subscription.rb
+++ b/lib/twingly/amqp/subscription.rb
@@ -112,18 +112,6 @@ module Twingly
         tag_name = Socket.gethostname
         @channel.generate_consumer_tag(tag_name)
       end
-
-      def setup_traps
-        %i[INT TERM].each do |signal|
-          Signal.trap(signal) do
-            # Exit fast if we've already got a signal since before
-            exit!(true) if cancel?
-
-            # Set cancel flag, cancels consumers
-            cancel!
-          end
-        end
-      end
     end
   end
 end


### PR DESCRIPTION
The call was accidentally removed in https://github.com/twingly/twingly-amqp/commit/22c799377a17274475c82e7e49fa7cabb62843db#diff-dad5e21a79b90b462ebf9695f101a6dbL37
The "faulty" version has already been released (as 4.3.0) and has now been used in a few projects for some time.

Since the signal_trap method it isn't called and we don't want the trap code in the gem anyways I removed it.

close #63