### PR TITLE
Remove workaround for frozen arrary bug

### DIFF
--- a/lib/twingly/amqp/session.rb
+++ b/lib/twingly/amqp/session.rb
@@ -27,10 +27,6 @@ module Twingly
         options[:pass]  ||= password_from_env
         options[:hosts] ||= hosts_from_env
 
-        # Used as a workaround for
-        # https://github.com/ruby-amqp/bunny/issues/446
-        options[:hosts] = options.fetch(:hosts).dup
-
         default_connection_options.merge(options)
       end
 

--- a/twingly-amqp.gemspec
+++ b/twingly-amqp.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |spec|
   spec.files         = Dir.glob("{lib}/**/*") + %w[README.md]
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "bunny", "~> 2.2"
+  spec.add_dependency "bunny", "~> 2.6", ">= 2.6.2"
 
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec", "~> 3"


### PR DESCRIPTION
Looks like i's included in the 2.6.2 release of bunny. See https://github.com/ruby-amqp/bunny/commit/565b5985f4d4ebf9980a5741e82b6ea9a823eacc

Close #57.