### PR TITLE
Allow custom options in ping message

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,6 +157,7 @@ urls = [
 ]
 
 # Optional, is merged with the default options above
+#   options given to #ping takes precedence over the default options
 options = {
   provider_name: "a-provider-name",
   source_ip:     "?.?.?.?",

--- a/README.md
+++ b/README.md
@@ -145,9 +145,11 @@ pinger = Twingly::AMQP::Pinger.new(
 
 # Optional, options can also be given to #ping
 pinger.default_ping_options do |options|
-  options.provider_name = "TestProvider"
-  options.source_ip     = "?.?.?.?"
-  options.priority      = 1
+  options.provider_name  = "TestProvider"
+  options.source_ip      = "?.?.?.?"
+  options.priority       = 1
+  # Optional keys/values that will be included in each ping message
+  options.custom_options = { my_option: "This is my own option" }
 end
 
 urls = [
@@ -159,6 +161,7 @@ options = {
   provider_name: "a-provider-name",
   source_ip:     "?.?.?.?",
   priority:      1,
+  custom_options: { my_other_option: "Another option" },
 }
 
 pinger.ping(urls, options) do |pinged_url|

--- a/lib/twingly/amqp/ping_options.rb
+++ b/lib/twingly/amqp/ping_options.rb
@@ -1,5 +1,3 @@
-require 'ostruct'
-
 module Twingly
   module AMQP
     class PingOptions

--- a/lib/twingly/amqp/ping_options.rb
+++ b/lib/twingly/amqp/ping_options.rb
@@ -5,8 +5,6 @@ module Twingly
 
       attr_reader :custom_options
 
-      REQUIRED_OPTIONS = %i[provider_name source_ip priority]
-
       def initialize(provider_name: nil, source_ip: nil, priority: nil,
                      custom_options: {})
         self.provider_name  = provider_name
@@ -36,7 +34,7 @@ module Twingly
 
       def validate
         missing_keys = to_h.select do |key, value|
-          REQUIRED_OPTIONS.include?(key) && value.to_s.empty?
+          key != :custom_options && value.to_s.empty?
         end.keys
 
         if missing_keys.any?

--- a/lib/twingly/amqp/ping_options.rb
+++ b/lib/twingly/amqp/ping_options.rb
@@ -19,7 +19,6 @@ module Twingly
 
       def to_h
         required_options = {
-          automatic_ping: false,
           provider_name:  provider_name,
           source_ip:      source_ip,
           priority:       priority,

--- a/lib/twingly/amqp/ping_options.rb
+++ b/lib/twingly/amqp/ping_options.rb
@@ -17,7 +17,7 @@ module Twingly
 
       def custom_options=(options)
         unless options.respond_to?(:to_h)
-          raise ArgumentError, "Options must respond to 'to_h'"
+          raise ArgumentError, "custom_options must respond to 'to_h'"
         end
 
         @custom_options = options.to_h

--- a/lib/twingly/amqp/ping_options.rb
+++ b/lib/twingly/amqp/ping_options.rb
@@ -20,9 +20,8 @@ module Twingly
           provider_name:  provider_name,
           source_ip:      source_ip,
           priority:       priority,
+          custom_options: custom_options,
         }
-
-        custom_options.merge(required_options)
       end
 
       def validate

--- a/lib/twingly/amqp/ping_options.rb
+++ b/lib/twingly/amqp/ping_options.rb
@@ -1,7 +1,9 @@
 module Twingly
   module AMQP
     class PingOptions
-      attr_accessor :provider_name, :source_ip, :priority, :custom_options
+      attr_accessor :provider_name, :source_ip, :priority
+
+      attr_reader :custom_options
 
       REQUIRED_OPTIONS = %i[provider_name source_ip priority]
 
@@ -15,8 +17,16 @@ module Twingly
         yield self if block_given?
       end
 
+      def custom_options=(options)
+        unless options.respond_to?(:to_h)
+          raise ArgumentError, "Options must respond to 'to_h'"
+        end
+
+        @custom_options = options.to_h
+      end
+
       def to_h
-        required_options = {
+        {
           provider_name:  provider_name,
           source_ip:      source_ip,
           priority:       priority,

--- a/lib/twingly/amqp/ping_options.rb
+++ b/lib/twingly/amqp/ping_options.rb
@@ -1,27 +1,38 @@
+require 'ostruct'
+
 module Twingly
   module AMQP
     class PingOptions
-      attr_accessor :provider_name, :source_ip, :priority
+      attr_accessor :provider_name, :source_ip, :priority, :custom_options
 
-      def initialize(provider_name: nil, source_ip: nil, priority: nil)
-        self.provider_name = provider_name
-        self.source_ip     = source_ip
-        self.priority      = priority
+      REQUIRED_OPTIONS = %i[provider_name source_ip priority]
+
+      def initialize(provider_name: nil, source_ip: nil, priority: nil,
+                     custom_options: {})
+        self.provider_name  = provider_name
+        self.source_ip      = source_ip
+        self.priority       = priority
+        self.custom_options = custom_options
 
         yield self if block_given?
       end
 
       def to_h
-        {
+        required_options = {
           automatic_ping: false,
           provider_name:  provider_name,
           source_ip:      source_ip,
           priority:       priority,
         }
+
+        custom_options.merge(required_options)
       end
 
       def validate
-        missing_keys = to_h.select { |_, value| value.to_s.empty? }.keys
+        missing_keys = to_h.select do |key, value|
+          REQUIRED_OPTIONS.include?(key) && value.to_s.empty?
+        end.keys
+
         if missing_keys.any?
           raise ArgumentError, "Required options not set: #{missing_keys}"
         end
@@ -29,9 +40,10 @@ module Twingly
 
       def merge(other)
         PingOptions.new do |options|
-          options.provider_name = other.provider_name || provider_name
-          options.source_ip     = other.source_ip     || source_ip
-          options.priority      = other.priority      || priority
+          options.provider_name  = other.provider_name || provider_name
+          options.source_ip      = other.source_ip     || source_ip
+          options.priority       = other.priority      || priority
+          options.custom_options = custom_options.merge(other.custom_options)
         end
       end
     end

--- a/spec/integration/twingly/amqp/pinger_spec.rb
+++ b/spec/integration/twingly/amqp/pinger_spec.rb
@@ -61,7 +61,6 @@ describe Twingly::AMQP::Pinger do
             priority:       priority,
             source_ip:      source_ip,
             url:            urls,
-            automatic_ping: false,
           }
         end
 

--- a/spec/unit/twingly/amqp/ping_options_spec.rb
+++ b/spec/unit/twingly/amqp/ping_options_spec.rb
@@ -69,10 +69,12 @@ describe Twingly::AMQP::PingOptions do
   describe "#to_h" do
     let(:expected) do
       {
-        provider_name:        provider_name,
-        source_ip:            source_ip,
-        priority:             priority,
-        custom_option_name => custom_option_value,
+        provider_name:  provider_name,
+        source_ip:      source_ip,
+        priority:       priority,
+        custom_options: {
+          custom_option_name => custom_option_value,
+        },
       }
     end
 
@@ -84,14 +86,6 @@ describe Twingly::AMQP::PingOptions do
       it "should return a hash containing correct options" do
         expect(subject).to eq(expected)
       end
-    end
-
-    context "when there is a name conflict with custom_options" do
-      let(:custom_option_name) { :provider_name }
-
-      subject { hash.fetch(:provider_name) }
-
-      it { is_expected.to eq(provider_name) }
     end
   end
 

--- a/spec/unit/twingly/amqp/ping_options_spec.rb
+++ b/spec/unit/twingly/amqp/ping_options_spec.rb
@@ -69,7 +69,6 @@ describe Twingly::AMQP::PingOptions do
   describe "#to_h" do
     let(:expected) do
       {
-        automatic_ping:       false,
         provider_name:        provider_name,
         source_ip:            source_ip,
         priority:             priority,

--- a/spec/unit/twingly/amqp/ping_options_spec.rb
+++ b/spec/unit/twingly/amqp/ping_options_spec.rb
@@ -52,6 +52,15 @@ describe Twingly::AMQP::PingOptions do
       it "should raise an exception" do
         expect { described_class.new(options) }.to raise_error(ArgumentError)
       end
+
+      context "when given custom_options not responding to 'to_h'" do
+        let(:custom_options) { "not a hash" }
+
+        it do
+          expect { subject }.to raise_error(ArgumentError,
+                                            /must respond to 'to_h'/)
+        end
+      end
     end
 
     context "when given a block" do
@@ -62,6 +71,15 @@ describe Twingly::AMQP::PingOptions do
         end
 
         expect(yielded_options).to equal(options)
+      end
+    end
+  end
+
+  describe "#custom_options=" do
+    context "when given object not responding to 'to_h'" do
+      it do
+        expect { subject.custom_options = "not a hash" }
+          .to raise_error(ArgumentError, /must respond to 'to_h'/)
       end
     end
   end


### PR DESCRIPTION
Allows you to send any options in each ping message. This makes it easier for users of this gem to add new options in the future as no changes has to be made to twingly-amqp then.

Related to twingly/norrstrom#123