### PR TITLE
Make it possible to subscribe using multiple routing keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ end
 subscription = Twingly::AMQP::Subscription.new(
   queue_name:       "crawler-urls",
   exchange_topic:   "url-exchange", # Optional, uses the default exchange if omitted
-  routing_key:      "url.blog",     # Optional, uses the default exchange if omitted
+  routing_key:      "url.blog",     # Optional, uses the default exchange if omitted, also accepts an array of routing keys
   consumer_threads: 4,              # Optional
   prefetch:         20,             # Optional
   max_length:       10_000,         # Optional

--- a/README.md
+++ b/README.md
@@ -55,11 +55,11 @@ end
 ```ruby
 subscription = Twingly::AMQP::Subscription.new(
   queue_name:       "crawler-urls",
-  exchange_topic:   "url-exchange", # Optional, uses the default exchange if omitted
-  routing_key:      "url.blog",     # Optional, uses the default exchange if omitted, also accepts an array of routing keys
-  consumer_threads: 4,              # Optional
-  prefetch:         20,             # Optional
-  max_length:       10_000,         # Optional
+  exchange_topic:   "url-exchange",        # Optional, uses the default exchange if omitted
+  routing_keys:     %w(url.blog url.post), # Optional, uses the default exchange if omitted
+  consumer_threads: 4,                     # Optional
+  prefetch:         20,                    # Optional
+  max_length:       10_000,                # Optional
 )
 
 subscription.on_exception { |exception| puts "Oh noes! #{exception.message}" }

--- a/lib/twingly/amqp/subscription.rb
+++ b/lib/twingly/amqp/subscription.rb
@@ -14,6 +14,11 @@ module Twingly
         @prefetch         = prefetch
         @max_length       = max_length
 
+        unless routing_key.nil?
+          warn "[DEPRECATION] `routing_key` is deprecated. "\
+               "Please use `routing_keys` instead."
+        end
+
         connection ||= Connection.instance
         @channel = create_channel(connection)
         @queue   = @channel.queue(@queue_name, queue_options)

--- a/lib/twingly/amqp/subscription.rb
+++ b/lib/twingly/amqp/subscription.rb
@@ -5,11 +5,11 @@ module Twingly
   module AMQP
     class Subscription
       def initialize(queue_name:, exchange_topic: nil, routing_key: nil,
-                     consumer_threads: 4, prefetch: 20, connection: nil,
-                     max_length: nil)
+                     routing_keys: nil, consumer_threads: 4, prefetch: 20,
+                     connection: nil, max_length: nil)
         @queue_name       = queue_name
         @exchange_topic   = exchange_topic
-        @routing_keys     = Array(routing_key)
+        @routing_keys     = Array(routing_keys || routing_key)
         @consumer_threads = consumer_threads
         @prefetch         = prefetch
         @max_length       = max_length

--- a/lib/twingly/amqp/subscription.rb
+++ b/lib/twingly/amqp/subscription.rb
@@ -18,7 +18,7 @@ module Twingly
         @channel = create_channel(connection)
         @queue   = @channel.queue(@queue_name, queue_options)
 
-        if @exchange_topic && !@routing_keys.empty?
+        if @exchange_topic && @routing_keys.any?
           exchange = @channel.topic(@exchange_topic, durable: true)
 
           @routing_keys.each do |routing_key|

--- a/lib/twingly/amqp/subscription.rb
+++ b/lib/twingly/amqp/subscription.rb
@@ -9,7 +9,7 @@ module Twingly
                      max_length: nil)
         @queue_name       = queue_name
         @exchange_topic   = exchange_topic
-        @routing_key      = routing_key
+        @routing_keys     = Array(routing_key)
         @consumer_threads = consumer_threads
         @prefetch         = prefetch
         @max_length       = max_length
@@ -18,9 +18,12 @@ module Twingly
         @channel = create_channel(connection)
         @queue   = @channel.queue(@queue_name, queue_options)
 
-        if @exchange_topic && @routing_key
+        if @exchange_topic && !@routing_keys.empty?
           exchange = @channel.topic(@exchange_topic, durable: true)
-          @queue.bind(exchange, routing_key: @routing_key)
+
+          @routing_keys.each do |routing_key|
+            @queue.bind(exchange, routing_key: routing_key)
+          end
         end
 
         @before_handle_message_callback = proc {}

--- a/lib/twingly/amqp/subscription.rb
+++ b/lib/twingly/amqp/subscription.rb
@@ -14,7 +14,7 @@ module Twingly
         @prefetch         = prefetch
         @max_length       = max_length
 
-        unless routing_key.nil?
+        if routing_key
           warn "[DEPRECATION] `routing_key` is deprecated. "\
                "Please use `routing_keys` instead."
         end

--- a/spec/integration/twingly/amqp/subscription_spec.rb
+++ b/spec/integration/twingly/amqp/subscription_spec.rb
@@ -52,6 +52,12 @@ describe Twingly::AMQP::Subscription do
       it { expect { subject }.not_to raise_error }
     end
 
+    context "when the routing_keys argument isn't an array" do
+      let(:routing_keys) { "a-single-routing-key" }
+
+      it { expect { subject }.not_to raise_error }
+    end
+
     context "with max_length set (bounded queue)" do
       let(:max_length) { 10 }
 

--- a/spec/integration/twingly/amqp/subscription_spec.rb
+++ b/spec/integration/twingly/amqp/subscription_spec.rb
@@ -16,6 +16,7 @@ describe Twingly::AMQP::Subscription do
   let(:payload_json)   { { url: payload_url }.to_json }
   let(:exchange_topic) { "twingly-amqp.exchange.test" }
   let(:routing_key)    { "url.blog" }
+  let(:routing_keys)   { [routing_key] }
   let(:exchange) do
     channel = amqp_connection.create_channel
     channel.confirm_select
@@ -27,7 +28,7 @@ describe Twingly::AMQP::Subscription do
       described_class.new(
         queue_name:     queue_name + ".bounded",
         exchange_topic: exchange_topic,
-        routing_key:    routing_key,
+        routing_keys:   routing_keys,
         max_length:     max_length,
       )
     end
@@ -38,6 +39,18 @@ describe Twingly::AMQP::Subscription do
     end
 
     specify { expect(subject).to be_a(described_class) }
+
+    context "when using the deprecated routing_key argument" do
+      subject do
+        described_class.new(
+          queue_name:     queue_name,
+          exchange_topic: exchange_topic,
+          routing_key:    routing_key,
+        )
+      end
+
+      it { expect { subject }.not_to raise_error }
+    end
 
     context "with max_length set (bounded queue)" do
       let(:max_length) { 10 }
@@ -62,7 +75,7 @@ describe Twingly::AMQP::Subscription do
       described_class.new(
         queue_name:     queue_name,
         exchange_topic: exchange_topic,
-        routing_key:    routing_key,
+        routing_keys:   routing_keys,
       )
     end
 
@@ -89,7 +102,7 @@ describe Twingly::AMQP::Subscription do
       described_class.new(
         queue_name:     queue_name,
         exchange_topic: exchange_topic,
-        routing_key:    routing_key,
+        routing_keys:   routing_keys,
       )
     end
 
@@ -101,7 +114,7 @@ describe Twingly::AMQP::Subscription do
       described_class.new(
         queue_name:     queue_name,
         exchange_topic: exchange_topic,
-        routing_key:    routing_key,
+        routing_keys:   routing_keys,
       )
     end
 
@@ -128,7 +141,7 @@ describe Twingly::AMQP::Subscription do
         }
       end
 
-      let(:routing_key)   { routing_keys_and_payload_urls.keys }
+      let(:routing_keys)  { routing_keys_and_payload_urls.keys }
       let(:expected_urls) { routing_keys_and_payload_urls.values }
 
       it "should receive messages matching any of the routing keys" do

--- a/spec/integration/twingly/amqp/subscription_spec.rb
+++ b/spec/integration/twingly/amqp/subscription_spec.rb
@@ -166,7 +166,7 @@ describe Twingly::AMQP::Subscription do
           end
         end
 
-        expect(received_urls).to contain_exactly(*expected_urls)
+        expect(received_urls).to match_array(expected_urls)
       end
     end
 


### PR DESCRIPTION
Kept the old name of the parameter (routing_key), because changing it would have been a breaking change.
There's only one project in which we will use the "multiple routing keys" feature, so I think I can live with this name.

close #69