### PR TITLE
Do not convert Array to Hash when publishing

### DIFF
--- a/lib/twingly/amqp/publisher.rb
+++ b/lib/twingly/amqp/publisher.rb
@@ -5,11 +5,18 @@ module Twingly
   module AMQP
     module Publisher
       def publish(message)
-        raise ArgumentError unless message.respond_to?(:to_h)
+        payload =
+          if message.kind_of?(Array)
+            message
+          elsif message.respond_to?(:to_h)
+            message.to_h
+          else
+            raise ArgumentError
+          end
 
-        payload = message.to_h.to_json
-        opts    = options.to_h
-        @exchange.publish(payload, opts)
+        json_payload = payload.to_json
+        opts         = options.to_h
+        @exchange.publish(json_payload, opts)
       end
 
       # only used by tests to avoid sleeping

--- a/spec/publisher_examples.rb
+++ b/spec/publisher_examples.rb
@@ -20,10 +20,11 @@ shared_examples "publisher" do
       [
         { some: "data" },
         OpenStruct.new(some: "data"),
+        nil,
       ].each do |payload_object|
         context "when given a hash-like payload '#{payload_object.inspect}'" do
           let(:payload) { payload_object }
-          let(:expected_payload) { { some: "data" } }
+          let(:expected_payload) { payload_object.to_h }
 
           it "does publish the message" do
             expect(actual_payload).to eq(expected_payload)

--- a/spec/publisher_examples.rb
+++ b/spec/publisher_examples.rb
@@ -35,8 +35,8 @@ shared_examples "publisher" do
       end
     end
 
-    context "when given a non-hash/non-array payload" do
-      let(:payload) { "not a hash or array" }
+    context "when given an incompatible payload" do
+      let(:payload) { "not a valid payload" }
 
       it "raises an ArgumentError" do
         expect { subject.publish(payload) }.to raise_error(ArgumentError)

--- a/spec/publisher_examples.rb
+++ b/spec/publisher_examples.rb
@@ -4,7 +4,12 @@ shared_examples "publisher" do
   let(:payload) { { some: "data" } }
 
   describe "#publish" do
-    let(:json_payload)   { amqp_queue.pop.last }
+    let(:json_payload) do
+      _, _, json_payload = amqp_queue.pop
+
+      json_payload
+    end
+
     let(:actual_payload) { JSON.parse(json_payload, symbolize_names: true) }
 
     context "when given a valid payload" do


### PR DESCRIPTION
This changes the behaviour a bit, so a major version bump is needed for this (although to my knowledge we have ever used the Array->Hash conversion in any of our projects).

Had to use `.kind_of?(Array)` instead of `.respond_to?(:to_a)` since ruby Hashes responds to `to_a` and we don't want to convert all Hashes to Arrays.

close #71