### PR TITLE
Use more recent rubies on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,9 @@ sudo: false
 services:
   - rabbitmq
 rvm:
-  - 2.2
-  - 2.4.2
+  - 2.4.5
+  - 2.5.3
+  - 2.6.1
 cache: bundler
 notifications:
   email: false


### PR DESCRIPTION
Dropping Ruby 2.2 as it's unsupported and we do not use it.