### PR TITLE
Change consumer thread default to 1 to match Bunny

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,9 +3,9 @@ sudo: false
 services:
   - rabbitmq
 rvm:
-  - 2.4.5
-  - 2.5.3
-  - 2.6.1
+  - 2.4.6
+  - 2.5.5
+  - 2.6.3
 cache: bundler
 notifications:
   email: false

--- a/lib/twingly/amqp/subscription.rb
+++ b/lib/twingly/amqp/subscription.rb
@@ -5,7 +5,7 @@ module Twingly
   module AMQP
     class Subscription
       def initialize(queue_name:, exchange_topic: nil, routing_key: nil,
-                     routing_keys: nil, consumer_threads: 4, prefetch: 20,
+                     routing_keys: nil, consumer_threads: 1, prefetch: 20,
                      connection: nil, max_length: nil)
         @queue_name       = queue_name
         @exchange_topic   = exchange_topic


### PR DESCRIPTION
From Bunny documentation, http://rubybunny.info/articles/concurrency.html#consumer_work_pools:

> Every channel maintains a fixed size thread pool used to dispatch
deliveries (messages pushed by RabbitMQ to consumers). By default every
pool has size of 1 to guarantee ordered message processing by default.

Close #68