### PR TITLE
Test with latest Rubies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,10 +24,10 @@ jobs:
       fail-fast: false
       matrix:
         include:
-        - { ruby: 2.6.7 }
-        - { ruby: 2.7.3 }
-        - { ruby: 3.0.1 }
-        - { ruby: jruby-9.2.17.0, allow-failure: true }
+        - { ruby: 2.7.6 }
+        - { ruby: 3.0.4 }
+        - { ruby: 3.1.2 }
+        - { ruby: jruby-9.3.4.0, allow-failure: true }
 
     steps:
     - name: Checkout code


### PR DESCRIPTION
Drop Ruby 2.6 since it's EOL since 2022-04-12.