### PR TITLE
Use quorum queues by default instead of classic queues

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,8 @@ subscription = Twingly::AMQP::Subscription.new(
   consumer_threads: 4,                     # Optional
   prefetch:         20,                    # Optional
   max_length:       10_000,                # Optional
+  queue_type:       :classic,              # Optional, which type of queue to create,
+                                           # possible values are :classic or :quorum
 )
 
 subscription.on_exception { |exception| puts "Oh noes! #{exception.message}" }
@@ -141,6 +143,8 @@ publisher = Twingly::AMQP::DefaultExchangePublisher.delayed(
   target_queue_name: "my_queue",         # Queue which delayed messages will be
                                          #   published to after the delay has elapsed
   delay_ms:          60_000,
+  delay_queue_type:  :classic,           # Optional. Which type of queue to define the delay
+                                         # queue as. Possible values are :classic or :quorum
 )
 
 # Publishes message to the delay queue. After delay_ms has passed,

--- a/README.md
+++ b/README.md
@@ -59,8 +59,8 @@ subscription = Twingly::AMQP::Subscription.new(
   consumer_threads: 4,                     # Optional
   prefetch:         20,                    # Optional
   max_length:       10_000,                # Optional
-  queue_type:       :classic,              # Optional, which type of queue to create,
-                                           # possible values are :classic or :quorum
+  queue_type:       :quorum,               # Optional, which type of queue to create,
+                                           # possible values are :quorum (default) or :classic
 )
 
 subscription.on_exception { |exception| puts "Oh noes! #{exception.message}" }
@@ -143,8 +143,8 @@ publisher = Twingly::AMQP::DefaultExchangePublisher.delayed(
   target_queue_name: "my_queue",         # Queue which delayed messages will be
                                          #   published to after the delay has elapsed
   delay_ms:          60_000,
-  delay_queue_type:  :classic,           # Optional. Which type of queue to define the delay
-                                         # queue as. Possible values are :classic or :quorum
+  delay_queue_type:  :quorum,            # Optional. Which type of queue to define the delay queue
+                                         # as. Possible values are :quorum (default) or :classic
 )
 
 # Publishes message to the delay queue. After delay_ms has passed,

--- a/lib/twingly/amqp/default_exchange_publisher.rb
+++ b/lib/twingly/amqp/default_exchange_publisher.rb
@@ -11,7 +11,7 @@ module Twingly
         @exchange = connection.create_channel.default_exchange
       end
 
-      def self.delayed(delay_queue_name:, target_queue_name:, delay_ms:, delay_queue_type: :classic,
+      def self.delayed(delay_queue_name:, target_queue_name:, delay_ms:, delay_queue_type: :quorum,
                        connection: Connection.instance)
         Utilities.create_queue(delay_queue_name,
                                arguments: {

--- a/lib/twingly/amqp/default_exchange_publisher.rb
+++ b/lib/twingly/amqp/default_exchange_publisher.rb
@@ -11,12 +11,14 @@ module Twingly
         @exchange = connection.create_channel.default_exchange
       end
 
-      def self.delayed(delay_queue_name:, target_queue_name:, delay_ms:, connection: Connection.instance)
+      def self.delayed(delay_queue_name:, target_queue_name:, delay_ms:, delay_queue_type: :classic,
+                       connection: Connection.instance)
         Utilities.create_queue(delay_queue_name,
                                arguments: {
                                  "x-dead-letter-exchange":    DEFAULT_EXCHANGE,
                                  "x-dead-letter-routing-key": target_queue_name,
-                               })
+                               },
+                               queue_type: delay_queue_type)
 
         new(queue_name: delay_queue_name, connection: connection).tap do |publisher|
           publisher.configure_publish_options do |options|

--- a/lib/twingly/amqp/subscription.rb
+++ b/lib/twingly/amqp/subscription.rb
@@ -3,13 +3,15 @@ module Twingly
     class Subscription
       def initialize(queue_name:, exchange_topic: nil, routing_key: nil,
                      routing_keys: nil, consumer_threads: 1, prefetch: 20,
-                     connection: Connection.instance, max_length: nil)
+                     connection: Connection.instance, max_length: nil,
+                     queue_type: :classic)
         @queue_name       = queue_name
         @exchange_topic   = exchange_topic
         @routing_keys     = Array(routing_keys || routing_key)
         @consumer_threads = consumer_threads
         @prefetch         = prefetch
         @max_length       = max_length
+        @queue_type       = queue_type
         @cancel           = false
 
         if routing_key
@@ -18,7 +20,7 @@ module Twingly
         end
 
         @channel = create_channel(connection)
-        @queue   = @channel.queue(@queue_name, queue_options)
+        @queue   = create_queue
 
         if @exchange_topic && @routing_keys.any?
           exchange = @channel.topic(@exchange_topic, durable: true)
@@ -91,6 +93,17 @@ module Twingly
           @on_exception_callback.call(exception)
         end
         channel
+      end
+
+      def create_queue
+        case @queue_type
+        when :classic
+          @channel.queue(@queue_name, queue_options)
+        when :quorum
+          @channel.quorum_queue(@queue_name, queue_options)
+        else
+          raise ArgumentError, "Unknown queue type #{@queue_type}"
+        end
       end
 
       def queue_options

--- a/lib/twingly/amqp/subscription.rb
+++ b/lib/twingly/amqp/subscription.rb
@@ -4,7 +4,7 @@ module Twingly
       def initialize(queue_name:, exchange_topic: nil, routing_key: nil,
                      routing_keys: nil, consumer_threads: 1, prefetch: 20,
                      connection: Connection.instance, max_length: nil,
-                     queue_type: :classic)
+                     queue_type: :quorum)
         @queue_name       = queue_name
         @exchange_topic   = exchange_topic
         @routing_keys     = Array(routing_keys || routing_key)
@@ -101,10 +101,10 @@ module Twingly
 
       def create_queue
         case @queue_type
-        when :classic
-          @channel.queue(@queue_name, queue_options)
         when :quorum
           @channel.quorum_queue(@queue_name, queue_options)
+        when :classic
+          @channel.queue(@queue_name, queue_options)
         else
           raise ArgumentError, "Unknown queue type #{@queue_type}"
         end

--- a/lib/twingly/amqp/utilities.rb
+++ b/lib/twingly/amqp/utilities.rb
@@ -1,13 +1,16 @@
 module Twingly
   module AMQP
     module Utilities
-      def self.create_queue(queue_name, durable: true, arguments: {}, connection: Connection.instance)
+      def self.create_queue(queue_name, durable: true, arguments: {}, queue_type: :classic, connection: Connection.instance)
         connection.with_channel do |channel|
-          return channel.queue(
-            queue_name,
-            durable: durable,
-            arguments: arguments,
-          )
+          case queue_type
+          when :classic
+            return channel.queue(queue_name, durable: durable, arguments: arguments)
+          when :quorum
+            return channel.quorum_queue(queue_name, arguments: arguments)
+          else
+            raise ArgumentError, "Unknown queue type '#{queue_type}'"
+          end
         end
       end
     end

--- a/lib/twingly/amqp/utilities.rb
+++ b/lib/twingly/amqp/utilities.rb
@@ -1,13 +1,16 @@
 module Twingly
   module AMQP
     module Utilities
-      def self.create_queue(queue_name, durable: true, arguments: {}, queue_type: :classic, connection: Connection.instance)
+      def self.create_queue(queue_name, durable: true, arguments: {}, queue_type: :quorum, connection: Connection.instance)
         connection.with_channel do |channel|
           case queue_type
+          when :quorum
+            # Quorum queues are always durable, see https://www.rabbitmq.com/quorum-queues.html#feature-matrix
+            raise ArgumentError, "durable: false is not supported by quorum queues" unless durable
+
+            return channel.quorum_queue(queue_name, arguments: arguments)
           when :classic
             return channel.queue(queue_name, durable: durable, arguments: arguments)
-          when :quorum
-            return channel.quorum_queue(queue_name, arguments: arguments)
           else
             raise ArgumentError, "Unknown queue type '#{queue_type}'"
           end

--- a/spec/amqp_queue_context.rb
+++ b/spec/amqp_queue_context.rb
@@ -9,7 +9,7 @@ shared_context "amqp queue" do
 
   let(:default_exchange_queue) do
     channel = amqp_connection.create_channel
-    channel.queue(queue_name, durable: true)
+    channel.quorum_queue(queue_name)
   end
 
   let(:topic_exchange) do
@@ -18,7 +18,7 @@ shared_context "amqp queue" do
 
   let(:topic_exchange_queue) do
     channel = amqp_connection.create_channel
-    queue   = channel.queue(topic_queue_name)
+    queue   = channel.quorum_queue(topic_queue_name)
 
     queue.bind(topic_exchange)
   end

--- a/spec/integration/twingly/amqp/default_exchange_publisher_spec.rb
+++ b/spec/integration/twingly/amqp/default_exchange_publisher_spec.rb
@@ -37,6 +37,28 @@ describe Twingly::AMQP::DefaultExchangePublisher do
 
     it { is_expected.to be_a(described_class) }
 
+    context "setting the delay_queue_type to :quorum" do
+      subject(:delay_queue_publisher) do
+        described_class.delayed(
+          delay_queue_name:  delay_queue_name,
+          target_queue_name: target_queue_name,
+          delay_ms:          delay_ms,
+          delay_queue_type:  :quorum,
+          connection:        amqp_connection,
+        )
+      end
+
+      before { allow(Twingly::AMQP::Utilities).to receive(:create_queue) }
+
+      it "uses 'Utilities.create_queue' to create a quorum queue" do
+        delay_queue_publisher
+
+        expect(Twingly::AMQP::Utilities)
+          .to have_received(:create_queue)
+          .with(delay_queue_name, hash_including(queue_type: :quorum))
+      end
+    end
+
     describe "#publish" do
       let(:delay_ms)      { 100 }
       let(:delay_seconds) { delay_ms.to_f / 1000 }

--- a/spec/integration/twingly/amqp/default_exchange_publisher_spec.rb
+++ b/spec/integration/twingly/amqp/default_exchange_publisher_spec.rb
@@ -37,7 +37,7 @@ describe Twingly::AMQP::DefaultExchangePublisher do
 
     it { is_expected.to be_a(described_class) }
 
-    context "setting the delay_queue_type to :quorum" do
+    context "with delay_queue_type set to :quorum" do
       subject(:delay_queue_publisher) do
         described_class.delayed(
           delay_queue_name:  delay_queue_name,

--- a/spec/integration/twingly/amqp/subscription_spec.rb
+++ b/spec/integration/twingly/amqp/subscription_spec.rb
@@ -76,6 +76,40 @@ describe Twingly::AMQP::Subscription do
     end
   end
 
+  describe "queue_type" do
+    subject(:queue_type) { subscriber.raw_queue.arguments["x-queue-type"] }
+
+    let(:queue_options) { {} }
+    let(:subscriber) do
+      described_class.new(
+        queue_name: "#{queue_name}.quorum",
+        **queue_options,
+      )
+    end
+
+    after { subscriber.raw_queue.delete }
+
+    it "creates a queue with the default queue type (classic)" do
+      expect(queue_type).to be_nil
+    end
+
+    context "with queue_type set to :classic" do
+      let(:queue_options) { { queue_type: :classic } }
+
+      it "creates a queue with the default queue type (classic)" do
+        expect(queue_type).to be_nil
+      end
+    end
+
+    context "with queue_type set to :quorum" do
+      let(:queue_options) { { queue_type: :quorum } }
+
+      it "creates a quorum queue" do
+        expect(queue_type).to eq("quorum")
+      end
+    end
+  end
+
   describe "#message_count" do
     subject! do
       described_class.new(

--- a/spec/integration/twingly/amqp/utilities_spec.rb
+++ b/spec/integration/twingly/amqp/utilities_spec.rb
@@ -60,6 +60,32 @@ describe Twingly::AMQP::Utilities do
           end
         end
       end
+
+      describe "queue_type:" do
+        subject(:queue_type) { created_queue.arguments["x-queue-type"] }
+
+        context "by default" do
+          it { is_expected.to be_nil }
+        end
+
+        context "with queue_type: :classic" do
+          before { options[:queue_type] = :classic }
+
+          it { is_expected.to be_nil }
+        end
+
+        context "with queue_type: :quorum" do
+          before { options[:queue_type] = :quorum }
+
+          it { is_expected.to eq("quorum") }
+        end
+
+        context "with queue_type: :not_supported" do
+          before { options[:queue_type] = :not_supported }
+
+          it { expect { queue_type }.to raise_error(ArgumentError, "Unknown queue type 'not_supported'") }
+        end
+      end
     end
   end
 end

--- a/twingly-amqp.gemspec
+++ b/twingly-amqp.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |spec|
   spec.files         = Dir.glob("{lib}/**/*") + %w[README.md]
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "bunny", ">= 2.7.3"
+  spec.add_dependency "bunny", ">= 2.20.0"
 
   spec.add_development_dependency "rake", "~> 12"
   spec.add_development_dependency "rspec", "~> 3"


### PR DESCRIPTION
Now we support both classic queues (which is what we used before), and [quorum queues](https://www.rabbitmq.com/quorum-queues.html).

Only ["mirrored classic queues" are deprecated](https://www.rabbitmq.com/ha.html), not classic queues in general, so I opted to continue supporting classic queues in this gem, even though we'll most likely not use them once we have switched all of our production queues to quorum queues.

I added an extra argument to the classes that creates queues, which tells them what kind of queue to create. Based on that argument, the classes then either uses the `Channel#queue` or `Channel#quorum_queue` method to setup the queue. Those helper methods were added to Bunny in https://github.com/ruby-amqp/bunny/commit/0cae5f8766afc125c5cdd60e90b2b7962961b4c1

Related to https://github.com/twingly/ansible/issues/2316

Also a bit related to https://github.com/twingly/twingly-amqp/issues/78 (as we now support the `x-queue-type` argument). I'm not sure we need to support the `x-quorum-initial-group-size` argument mentioned there though, as we will only have three servers, which is the default value for that argument.

---

### Before merge

- [x] Before merging this we should finish https://github.com/twingly/ansible/pull/2439
- [x] Test the changes made here in one project, just so we know if the changes made here are enough to support quorum queues - *Tested it in Imse. I made some changes here after the test though, but that was just changing the default type of queue, so I don't think we need to try that out before merging.*