### PR TITLE
Make sure Subscriber tests wait for messages to be consumed

### DIFF
--- a/lib/twingly/amqp/publisher.rb
+++ b/lib/twingly/amqp/publisher.rb
@@ -16,7 +16,7 @@ module Twingly
         @exchange.publish(json_payload, opts)
       end
 
-      # only used by tests to avoid sleeping
+      # Only used by tests to lessen the time we need to sleep
       def publish_with_confirm(message)
         channel = @exchange.channel
         channel.confirm_select unless channel.using_publisher_confirmations?


### PR DESCRIPTION
We previously assumed "publisher confirms" in RabbitMQ would wait for the messages to be consumed by a subscriber, but as it turns out, it only waits for the messages to be put onto a queue (there are some more details on it in [the documentation](https://www.rabbitmq.com/confirms.html#when-publishes-are-confirmed)).

I added a sleep to the code, so that we give the subscriber time to handle any messages before we continue with the test. I found no better way to do this that to add a sleep. The tests for Bunny uses sleeps too, for example see [this spec][1], so it seems like that's the best way.

I guess we could now remove the "pubisher confirms" feature from twingly-amqp, as we don't really need it. We added it so we didn't have to sleep (in #50), but it turns out we do need the sleep after all. However, the "publisher confirms" ensures that the RabbitMQ server is ready, so it still does some good, so I think we can keep it around anyway.

[1]: https://github.com/ruby-amqp/bunny/blob/80a8fc7aa0cd73f8778df87ae05f28c443d10c0d/spec/higher_level_api/integration/exchange_bind_spec.rb#L24-L27

close #102