### PR TITLE
Make it possible to override publishing options

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,9 @@ publisher.configure_publish_options do |options|
 end
 
 publisher.publish({ my: "data" })
+
+publisher.publish({ my: "other_data" }, routing_key: "my_other_key") # Override routing_key or other publishing options
+                                                                     # accepted by Bunny::Exchange#publish
 ```
 
 ### Publish delayed messages

--- a/lib/twingly/amqp/publisher.rb
+++ b/lib/twingly/amqp/publisher.rb
@@ -1,7 +1,7 @@
 module Twingly
   module AMQP
     module Publisher
-      def publish(message)
+      def publish(message, opts = {})
         payload =
           if message.kind_of?(Array)
             message
@@ -11,17 +11,17 @@ module Twingly
             raise ArgumentError
           end
 
-        json_payload = payload.to_json
-        opts         = options.to_h
-        @exchange.publish(json_payload, opts)
+        json_payload       = payload.to_json
+        publishing_options = options.to_h.merge(opts)
+        @exchange.publish(json_payload, publishing_options)
       end
 
       # Only used by tests to lessen the time we need to sleep
-      def publish_with_confirm(message)
+      def publish_with_confirm(message, opts = {})
         channel = @exchange.channel
         channel.confirm_select unless channel.using_publisher_confirmations?
 
-        publish(message)
+        publish(message, opts)
 
         @exchange.wait_for_confirms
       end


### PR DESCRIPTION
This lets the `TopicExchangePublisher#publish` method override the previously set routing_key, which makes it possible to publish messages having different routing keys.

This also enables us to set [all other publishing options][1] per message, which before were only possible to change by reconfiguring the publisher.

Close #60

[1]: https://www.rubydoc.info/github/ruby-amqp/bunny/Bunny/Exchange#publish-instance_method