### PR TITLE
Add channel error callback to Subscription

### DIFF
--- a/lib/twingly/amqp/subscription.rb
+++ b/lib/twingly/amqp/subscription.rb
@@ -34,6 +34,7 @@ module Twingly
 
         @before_handle_message_callback = proc {}
         @on_exception_callback          = proc {}
+        @on_error_callback              = proc { raise "Channel closed unexpectedly" }
       end
 
       def each_message(blocking: true, &block)
@@ -53,6 +54,10 @@ module Twingly
 
       def on_exception(&block)
         @on_exception_callback = block
+      end
+
+      def on_error(&block)
+        @on_error_callback = block
       end
 
       def message_count
@@ -95,6 +100,9 @@ module Twingly
         channel.on_uncaught_exception do |exception, _|
           Twingly::AMQP.configuration.logger.error(exception)
           @on_exception_callback.call(exception)
+        end
+        channel.on_error do |ch, ch_err|
+          @on_error_callback.call(ch, ch_err)
         end
         channel
       end

--- a/spec/integration/twingly/amqp/subscription_spec.rb
+++ b/spec/integration/twingly/amqp/subscription_spec.rb
@@ -292,14 +292,10 @@ describe Twingly::AMQP::Subscription do
       end
 
       it "should call error callback" do
-        on_error_called = false
-        subject.on_error do |channel, channel_error|
-          on_error_called = true
-        end
-
-        simulate_channel_error(subject.raw_queue.channel)
-
-        expect(on_error_called).to eq(true)
+        expect do |block|
+          subject.on_error(&block)
+          simulate_channel_error(subject.raw_queue.channel)
+        end.to yield_with_args(subject.raw_queue.channel, be_kind_of(AMQ::Protocol::Channel::Close))
       end
 
       context "when no error callback is configured" do

--- a/twingly-amqp.gemspec
+++ b/twingly-amqp.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |spec|
   spec.files         = Dir.glob("{lib}/**/*") + %w[README.md]
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "bunny", ">= 2.20.0"
+  spec.add_dependency "bunny", ">= 2.23.0"
 
   spec.add_development_dependency "rake", "~> 12"
   spec.add_development_dependency "rspec", "~> 3"


### PR DESCRIPTION
Introduced an on_error callback in Twingly::AMQP::Subscription to handle channel errors, with a default behaviour of raising an exception if not set. Updated tests to cover the new callback and changed the Bunny dependency to require version >= 2.23.0.

In 2.23.0 https://github.com/ruby-amqp/bunny/releases/tag/2.23.0 `#on_error` is invoked when channel closes because of a delivery acknowledgement timeout