### PR TITLE
Fix default `on_error` callback

### DIFF
--- a/lib/twingly/amqp/subscription.rb
+++ b/lib/twingly/amqp/subscription.rb
@@ -34,7 +34,7 @@ module Twingly
 
         @before_handle_message_callback = proc {}
         @on_exception_callback          = proc {}
-        @on_error_callback              = proc { raise "Channel closed unexpectedly" }
+        @on_error_callback              = proc {}
       end
 
       def each_message(blocking: true, &block)

--- a/spec/integration/twingly/amqp/subscription_spec.rb
+++ b/spec/integration/twingly/amqp/subscription_spec.rb
@@ -297,14 +297,6 @@ describe Twingly::AMQP::Subscription do
           simulate_channel_error(subject.raw_queue.channel)
         end.to yield_with_args(subject.raw_queue.channel, be_kind_of(AMQ::Protocol::Channel::Close))
       end
-
-      context "when no error callback is configured" do
-        it "should raise a default error" do
-          expect do
-            simulate_channel_error(subject.raw_queue.channel)
-          end.to raise_error(RuntimeError, "Channel closed unexpectedly")
-        end
-      end
     end
 
     context "without exchange_topic and routing_key" do


### PR DESCRIPTION
Raising an error in the `on_error` callback didn't behave as expected, see https://github.com/twingly/mezzofanti/pull/19#issuecomment-3073076097